### PR TITLE
Use .tar.gz from bintray

### DIFF
--- a/boost/boost.bzl
+++ b/boost/boost.bzl
@@ -61,9 +61,8 @@ def boost_library(name, defines=None, includes=None, hdrs=None, srcs=None, deps=
 def boost_deps():
   native.new_http_archive(
     name = "boost",
-    url = "https://nelhage.s3.amazonaws.com/rules_boost/boost_1_63_0.tar.bz2",
+    url = "https://dl.bintray.com/boostorg/release/1.63.0/source/boost_1_63_0.tar.gz",
     build_file = "@com_github_nelhage_boost//:BUILD.boost",
-    type = "tar.bz2",
     strip_prefix = "boost_1_63_0/",
-    sha256 = "beae2529f759f6b3bf3f4969a19c2e9d6f0c503edcb2de4a61d1428519fcb3b0",
+    sha256 = "fe34a4e119798e10b8cc9e565b3b0284e9fd3977ec8a1b19586ad1dec397088b",
   )


### PR DESCRIPTION
This is much faster for me. The .tar.gz from bintray downloads in ~12s,
compared to ~28s for the .tar.bz2 from S3. Additionally, Bazel can
uncompress the .tar.gz much faster: a no-op build takes ~13s compared to
1-3 minutes with the .tar.bz2.

See https://github.com/bazelbuild/bazel/issues/3397 for a partial cause
of the slow decompression.