### PR TITLE
Add a thread test

### DIFF
--- a/BUILD.boost
+++ b/BUILD.boost
@@ -13,6 +13,18 @@ boost_library(
 )
 
 boost_library(
+    name = "atomic",
+    hdrs = [
+        "boost/memory_order.hpp",
+    ],
+    deps = [
+        ":assert",
+        ":config",
+        ":type_traits",
+    ],
+)
+
+boost_library(
     name = "archive",
     deps = [
         ":assert",
@@ -102,6 +114,12 @@ boost_library(
 
 boost_library(
     name = "container",
+    hdrs = [
+        "libs/container/src/dlmalloc_2_8_6.c",
+    ],
+    srcs = [
+        "libs/container/src/dlmalloc_ext_2_8_6.c",
+    ],
     deps = [
         ":config",
         ":core",
@@ -254,6 +272,27 @@ boost_library(
 
 boost_library(
     name = "io",
+)
+
+boost_library(
+    name = "lexical_cast",
+    deps = [
+        ":array",
+        ":chrono",
+        ":config",
+        ":container",
+        ":detail",
+        ":integer",
+        ":limits",
+        ":math",
+        ":mpl",
+        ":noncopyable",
+        ":numeric",
+        ":range",
+        ":static_assert",
+        ":throw_exception",
+        ":type_traits",
+    ],
 )
 
 boost_library(
@@ -480,11 +519,26 @@ boost_library(
 
 boost_library(
     name = "thread",
+    srcs = [
+        "libs/thread/src/pthread/once.cpp",
+        "libs/thread/src/pthread/thread.cpp",
+    ],
+    hdrs = [
+        "libs/thread/src/pthread/once_atomic.cpp",
+    ],
+    linkopts = ["-lpthread"],
     deps = [
+        ":atomic",
+        ":bind",
         ":chrono",
         ":config",
         ":core",
+        ":date_time",
         ":detail",
+        ":exception",
+        ":function",
+        ":lexical_cast",
+        ":smart_ptr",
         ":system",
         ":type_traits",
     ],

--- a/boost/boost.bzl
+++ b/boost/boost.bzl
@@ -29,7 +29,8 @@ def includes_list(library_name):
 def hdr_list(library_name):
   return native.glob([p % (library_name,) for p in hdrs_patterns])
 
-def boost_library(name, defines=None, includes=None, hdrs=None, srcs=None, deps=None, copts=None, exclude_src=[]):
+def boost_library(name, defines=None, includes=None, hdrs=None, srcs=None,
+                  deps=None, copts=None, exclude_src=[], linkopts=None):
   if defines == None:
     defines = []
 
@@ -48,6 +49,9 @@ def boost_library(name, defines=None, includes=None, hdrs=None, srcs=None, deps=
   if copts == None:
     copts = []
 
+  if linkopts == None:
+    linkopts = []
+
   return native.cc_library(
     name = name,
     visibility = ["//visibility:public"],
@@ -57,6 +61,7 @@ def boost_library(name, defines=None, includes=None, hdrs=None, srcs=None, deps=
     srcs = [s for s in srcs_list(name) if s not in exclude_src] + srcs,
     deps = deps,
     copts = default_copts + copts,
+    linkopts = linkopts,
     licenses = ["notice"],
   )
 

--- a/test/BUILD
+++ b/test/BUILD
@@ -5,3 +5,13 @@ cc_test(
         "@boost//:test",
     ],
 )
+
+cc_test(
+    name = "thread_test",
+    size = "small",
+    srcs = ["thread_test.cc"],
+    deps = [
+        "@boost//:test",
+        "@boost//:thread",
+    ],
+)

--- a/test/thread_test.cc
+++ b/test/thread_test.cc
@@ -1,0 +1,13 @@
+#define BOOST_TEST_MODULE thread_test
+#include <boost/test/included/unit_test.hpp>
+#include <boost/thread.hpp>
+
+void thread()
+{
+}
+
+BOOST_AUTO_TEST_CASE( test_thread )
+{
+  boost::thread t{thread};
+  t.join();
+}


### PR DESCRIPTION
This involves adding a few more modules/dependencies so that it can
build. I also added `linkopts` to boost_library so that users don't need
to set it themselves. Tested on Ubuntu 14.04, bazel 0.7.0.