### PR TITLE
Add new targets and tests

### DIFF
--- a/BUILD.boost
+++ b/BUILD.boost
@@ -69,6 +69,7 @@ boost_library(
         ":is_placeholder",
         ":mem_fn",
         ":ref",
+        ":type",
         ":visit_each",
     ],
 )
@@ -118,9 +119,19 @@ boost_library(
 )
 
 boost_library(
+    name = "concept_archetype",
+    deps = [
+        ":config",
+        ":iterator",
+        ":mpl",
+    ],
+)
+
+boost_library(
     name = "concept_check",
     deps = [
         ":concept",
+        ":concept_archetype",
     ],
 )
 
@@ -173,10 +184,14 @@ boost_library(
 boost_library(
     name = "date_time",
     deps = [
+        ":algorithm",
+        ":io",
+        ":lexical_cast",
         ":mpl",
         ":operators",
         ":smart_ptr",
         ":static_assert",
+        ":tokenizer",
         ":type_traits",
     ],
 )
@@ -203,6 +218,7 @@ boost_library(
     ],
     deps = [
         ":config",
+        ":detail",
     ],
 )
 
@@ -229,6 +245,21 @@ boost_library(
 
 boost_library(
     name = "foreach",
+)
+
+boost_library(
+    name = "format",
+    deps = [
+        ":assert",
+        ":config",
+        ":detail",
+        ":limits",
+        ":optional",
+        ":shared_ptr",
+        ":throw_exception",
+        ":timer",
+        ":utility",
+    ],
 )
 
 boost_library(
@@ -274,6 +305,7 @@ boost_library(
     hdrs = [
         "boost/cstdint.hpp",
         "boost/integer_traits.hpp",
+        "boost/pending/integer_log2.hpp",
     ],
     deps = [
         ":static_assert",
@@ -281,7 +313,32 @@ boost_library(
 )
 
 boost_library(
+    name = "interprocess",
+    deps = [
+        ":assert",
+        ":checked_delete",
+        ":config",
+        ":container",
+        ":core",
+        ":date_time",
+        ":detail",
+        ":integer",
+        ":intrusive",
+        ":limits",
+        ":move",
+        ":static_assert",
+        ":type_traits",
+        ":unordered",
+        ":utility",
+    ],
+)
+
+boost_library(
     name = "iterator",
+    hdrs = [
+        "boost/function_output_iterator.hpp",
+        "boost/pointee.hpp",
+    ],
     deps = [
         ":detail",
         ":static_assert",
@@ -366,6 +423,10 @@ boost_library(
 
 boost_library(
     name = "multi_index",
+    hdrs = [
+        "boost/multi_index_container.hpp",
+        "boost/multi_index_container_fwd.hpp",
+    ],
     deps = [
         ":foreach",
         ":serialization",
@@ -410,10 +471,55 @@ boost_library(
 )
 
 boost_library(
+    name = "random",
+    deps = [
+        ":assert",
+        ":config",
+        ":detail",
+        ":foreach",
+        ":integer",
+        ":lexical_cast",
+        ":limits",
+        ":math",
+        ":mpl",
+        ":multi_index",
+        ":noncopyable",
+        ":operators",
+        ":range",
+        ":regex",
+        ":shared_ptr",
+        ":static_assert",
+        ":system",
+        ":test",
+        ":throw_exception",
+        ":timer",
+        ":tuple",
+        ":type_traits",
+        ":utility",
+    ],
+)
+
+boost_library(
     name = "range",
     deps = [
+        ":array",
+        ":assert",
         ":concept_check",
+        ":config",
+        ":detail",
+        ":functional",
+        ":integer",
+        ":iterator",
+        ":mpl",
+        ":noncopyable",
         ":optional",
+        ":preprocessor",
+        ":ref",
+        ":regex",
+        ":static_assert",
+        ":tuple",
+        ":type_traits",
+        ":utility",
     ],
 )
 
@@ -458,6 +564,20 @@ boost_library(
 )
 
 boost_library(
+    name = "scope_exit",
+    deps = [
+        ":config",
+        ":detail",
+        ":function",
+        ":mpl",
+        ":preprocessor",
+        ":type_traits",
+        ":typeof",
+        ":utility",
+    ],
+)
+
+boost_library(
     name = "scoped_array",
     deps = [
         ":checked_delete",
@@ -486,6 +606,38 @@ boost_library(
 )
 
 boost_library(
+    name = "signals2",
+    deps = [
+        ":assert",
+        ":bind",
+        ":checked_delete",
+        ":config",
+        ":core",
+        ":detail",
+        ":function",
+        ":iterator",
+        ":mpl",
+        ":multi_index",
+        ":noncopyable",
+        ":optional",
+        ":parameter",
+        ":predef",
+        ":preprocessor",
+        ":ref",
+        ":scoped_ptr",
+        ":shared_ptr",
+        ":smart_ptr",
+        ":swap",
+        ":throw_exception",
+        ":tuple",
+        ":type_traits",
+        ":utility",
+        ":variant",
+        ":visit_each",
+    ],
+)
+
+boost_library(
     name = "serialization",
     deps = [
         ":archive",
@@ -493,6 +645,7 @@ boost_library(
         ":call_traits",
         ":config",
         ":detail",
+        ":function",
         ":operators",
         ":type_traits",
     ],
@@ -501,7 +654,10 @@ boost_library(
 boost_library(
     name = "smart_ptr",
     hdrs = [
+        "boost/enable_shared_from_this.hpp",
         "boost/make_shared.hpp",
+        "boost/pointer_to_other.hpp",
+        "boost/weak_ptr.hpp",
     ],
     deps = [
         ":align",
@@ -521,6 +677,7 @@ boost_library(
     deps = [
         ":optional",
         ":ref",
+        ":utility",
     ],
 )
 
@@ -550,6 +707,7 @@ boost_library(
     name = "throw_exception",
     deps = [
         ":current_function",
+        ":detail",
         ":exception",
     ],
 )
@@ -586,6 +744,22 @@ boost_library(
 )
 
 boost_library(
+    name = "tokenizer",
+    hdrs = [
+        "boost/token_functions.hpp",
+        "boost/token_iterator.hpp",
+    ],
+    deps = [
+        ":assert",
+        ":config",
+        ":detail",
+        ":iterator",
+        ":mpl",
+        ":throw_exception",
+    ],
+)
+
+boost_library(
     name = "type",
     deps = [
         ":core",
@@ -613,6 +787,18 @@ boost_library(
 )
 
 boost_library(
+    name = "typeof",
+    deps = [
+        ":config",
+        ":detail",
+        ":mpl",
+        ":preprocessor",
+        ":type_traits",
+        ":utility",
+    ],
+)
+
+boost_library(
     name = "tuple",
 )
 
@@ -627,11 +813,39 @@ boost_library(
 )
 
 boost_library(
+    name = "unordered",
+    hdrs = [
+        "boost/unordered_map.hpp",
+        "boost/unordered_set.hpp",
+    ],
+    deps = [
+        ":assert",
+        ":config",
+        ":container",
+        ":detail",
+        ":functional",
+        ":iterator",
+        ":limits",
+        ":move",
+        ":preprocessor",
+        ":smart_ptr",
+        ":swap",
+        ":throw_exception",
+        ":tuple",
+        ":type_traits",
+        ":utility",
+    ],
+)
+
+boost_library(
     name = "utility",
     hdrs = [
+        "boost/compressed_pair.hpp",
         "boost/next_prior.hpp",
     ],
     deps = [
+        ":config",
+        ":detail",
         ":swap",
     ],
 )
@@ -671,12 +885,14 @@ boost_library(
 boost_library(
     name = "timer",
     deps = [
+        ":cerrno",
         ":chrono",
         ":config",
         ":cstdint",
         ":io",
         ":limits",
         ":system",
+        ":throw_exception",
     ],
 )
 

--- a/test/BUILD
+++ b/test/BUILD
@@ -1,9 +1,60 @@
 cc_test(
+    name = "bind_test",
+    size = "small",
+    srcs = ["bind_test.cc"],
+    deps = [
+        "@boost//:bind",
+        "@boost//:test",
+    ],
+)
+
+cc_test(
     name = "circular_buffer_test",
     size = "small",
     srcs = ["circular_buffer_test.cc"],
     deps = [
         "@boost//:circular_buffer",
+        "@boost//:test",
+    ],
+)
+
+cc_test(
+    name = "format_test",
+    size = "small",
+    srcs = ["format_test.cc"],
+    copts = ["-Wno-unused-value"],
+    deps = [
+        "@boost//:format",
+        "@boost//:test",
+    ],
+)
+
+cc_test(
+    name = "random_test",
+    size = "small",
+    srcs = ["random_test.cc"],
+    deps = [
+        "@boost//:random",
+        "@boost//:test",
+    ],
+)
+
+cc_test(
+    name = "scope_exit_test",
+    size = "small",
+    srcs = ["scope_exit_test.cc"],
+    deps = [
+        "@boost//:scope_exit",
+        "@boost//:test",
+    ],
+)
+
+cc_test(
+    name = "signals2_test",
+    size = "small",
+    srcs = ["signals2_test.cc"],
+    deps = [
+        "@boost//:signals2",
         "@boost//:test",
     ],
 )
@@ -23,5 +74,25 @@ cc_test(
     deps = [
         "@boost//:test",
         "@boost//:thread",
+    ],
+)
+
+cc_test(
+    name = "tokenizer_test",
+    size = "small",
+    srcs = ["tokenizer_test.cc"],
+    deps = [
+        "@boost//:test",
+        "@boost//:tokenizer",
+    ],
+)
+
+cc_test(
+    name = "unordered_test",
+    size = "small",
+    srcs = ["unordered_test.cc"],
+    deps = [
+        "@boost//:test",
+        "@boost//:unordered",
     ],
 )

--- a/test/bind_test.cc
+++ b/test/bind_test.cc
@@ -1,0 +1,13 @@
+#define BOOST_TEST_MODULE bind_test
+#include <boost/bind.hpp>
+#include <boost/test/included/unit_test.hpp>
+
+int f(int a, int b)
+{
+  return a + b;
+}
+
+BOOST_AUTO_TEST_CASE( test_bind )
+{
+  BOOST_TEST(boost::bind(f, 1, 2)() == 3);
+}

--- a/test/format_test.cc
+++ b/test/format_test.cc
@@ -1,0 +1,8 @@
+#define BOOST_TEST_MODULE format_test
+#include <boost/format.hpp>
+#include <boost/test/included/unit_test.hpp>
+
+BOOST_AUTO_TEST_CASE( test_format )
+{
+  BOOST_TEST((boost::format("hello %d") % 1).str() == "hello 1");
+}

--- a/test/random_test.cc
+++ b/test/random_test.cc
@@ -1,0 +1,11 @@
+#define BOOST_TEST_MODULE random_test
+#include <boost/random/mersenne_twister.hpp>
+#include <boost/random/uniform_int_distribution.hpp>
+#include <boost/test/included/unit_test.hpp>
+
+BOOST_AUTO_TEST_CASE( test_random )
+{
+  boost::random::mt19937 gen;
+  boost::random::uniform_int_distribution<> dist(1, 6);
+  BOOST_TEST(dist(gen) <= 6);
+}

--- a/test/scope_exit_test.cc
+++ b/test/scope_exit_test.cc
@@ -1,0 +1,18 @@
+#define BOOST_TEST_MODULE scope_exit_test
+#include <boost/scope_exit.hpp>
+#include <boost/test/included/unit_test.hpp>
+
+void f(bool *flag)
+{
+  bool commit = false;
+  BOOST_SCOPE_EXIT(&commit, &flag) {
+    *flag = true;
+  } BOOST_SCOPE_EXIT_END
+}
+
+BOOST_AUTO_TEST_CASE( test_scope_exit )
+{
+  bool flag = false;
+  f(&flag);
+  BOOST_TEST(flag);
+}

--- a/test/signals2_test.cc
+++ b/test/signals2_test.cc
@@ -1,0 +1,29 @@
+#define BOOST_TEST_MODULE signals2_test
+#include <boost/signals2.hpp>
+#include <boost/test/included/unit_test.hpp>
+
+class FlagSetter
+{
+ public:
+  FlagSetter(bool *flag) : flag(flag) {}
+
+  void operator()()
+  {
+    *flag = true;
+  }
+
+  bool *flag;
+};
+
+BOOST_AUTO_TEST_CASE( test_signals2 )
+{
+  bool called = false;
+
+  boost::signals2::signal<void ()> sig;
+  FlagSetter fs (&called);
+  sig.connect(fs);
+
+  BOOST_TEST(!called);
+  sig();
+  BOOST_TEST(called);
+}

--- a/test/tokenizer_test.cc
+++ b/test/tokenizer_test.cc
@@ -1,0 +1,11 @@
+#define BOOST_TEST_MODULE tokenizer_test
+#include <string>
+#include <boost/tokenizer.hpp>
+#include <boost/test/included/unit_test.hpp>
+
+BOOST_AUTO_TEST_CASE( test_tokenizer )
+{
+  std::string s = "foo bar";
+  boost::tokenizer<> tok(s);
+  BOOST_TEST(*(tok.begin()) == "foo");
+}

--- a/test/unordered_test.cc
+++ b/test/unordered_test.cc
@@ -1,0 +1,13 @@
+#define BOOST_TEST_MODULE unordered_test
+#include <string>
+#include <boost/unordered_map.hpp>
+#include <boost/test/included/unit_test.hpp>
+
+BOOST_AUTO_TEST_CASE( test_unordered )
+{
+  boost::unordered_map<std::string, int> m;
+
+  m["one"] = 1;
+
+  BOOST_TEST(m.at("one") == 1);
+}


### PR DESCRIPTION
New targets:
- format
- interprocess (no test because of filesystem troubles)
- random
- scope_exit
- signals2
- tokenizer
- unordered

Also adds some extra dependencies found by grepping the source files of the
corresponding packages.

These changes seemed uncontroversial to me, so I've packaged them up in one big PR as you suggested.