### PR TITLE
Fix the build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,6 +11,6 @@ jobs:
             - bazel-cache
 
       - run: apt-get update && apt-get -y install pkg-config zip g++ zlib1g-dev unzip python curl
-      - run: cd /tmp/ && curl -LO https://github.com/bazelbuild/bazel/releases/download/0.5.4/bazel-0.5.4-installer-linux-x86_64.sh
-      - run: bash /tmp/bazel-0.5.4-installer-linux-x86_64.sh
+      - run: cd /tmp/ && curl -LO https://github.com/bazelbuild/bazel/releases/download/0.7.0/bazel-0.7.0-installer-linux-x86_64.sh
+      - run: bash /tmp/bazel-0.7.0-installer-linux-x86_64.sh
       - run: cd test && bazel test --test_output=errors //...

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,5 +13,5 @@ jobs:
       - run: apt-get update && apt-get -y install pkg-config zip g++ zlib1g-dev unzip python curl
       - run: cd /tmp/ && curl -LO https://github.com/bazelbuild/bazel/releases/download/0.7.0/bazel-0.7.0-installer-linux-x86_64.sh
       - run: bash /tmp/bazel-0.7.0-installer-linux-x86_64.sh
-      - run: cp .bazelrc.circle .bazelrc
+      - run: cd test && cp .bazelrc.circle .bazelrc
       - run: cd test && bazel test --test_output=errors //...

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,4 +13,5 @@ jobs:
       - run: apt-get update && apt-get -y install pkg-config zip g++ zlib1g-dev unzip python curl
       - run: cd /tmp/ && curl -LO https://github.com/bazelbuild/bazel/releases/download/0.7.0/bazel-0.7.0-installer-linux-x86_64.sh
       - run: bash /tmp/bazel-0.7.0-installer-linux-x86_64.sh
+      - run: cp .bazelrc.circle .bazelrc
       - run: cd test && bazel test --test_output=errors //...

--- a/test/.bazelrc.circle
+++ b/test/.bazelrc.circle
@@ -1,0 +1,8 @@
+# Limit memory usage, both by bazel and by the subprocesses it spawns
+startup --host_jvm_args=-Xms512m
+startup --host_jvm_args=-Xmx1024m
+build --local_resources=4096,4,1.0
+test --ram_utilization_factor=10
+
+# This is so we understand failures better
+build --verbose_failures


### PR DESCRIPTION
Bump to Bazel 0.7, and import a bazelrc that constrains us to appropriate memory usage for Circle.