### PR TITLE
Add Boost.Iostreams

### DIFF
--- a/BUILD.boost
+++ b/BUILD.boost
@@ -369,6 +369,35 @@ boost_library(
 )
 
 boost_library(
+    name = "iostreams",
+    deps = [
+        ":assert",
+        ":bind",
+        ":call_traits",
+        ":checked_delete",
+        ":config",
+        ":detail",
+        ":function",
+        ":integer",
+        ":mpl",
+        ":noncopyable",
+        ":preprocessor",
+        ":random",
+        ":range",
+        ":ref",
+        ":regex",
+        ":shared_ptr",
+        ":static_assert",
+        ":throw_exception",
+        ":type",
+        ":type_traits",
+        ":utility",
+        "@net_zlib_zlib//:zlib",
+        "@org_bzip_bzip2//:bz2lib",
+    ],
+)
+
+boost_library(
     name = "lexical_cast",
     deps = [
         ":array",

--- a/BUILD.bzip2
+++ b/BUILD.bzip2
@@ -1,0 +1,23 @@
+# Description:
+#   bzip2 is a high-quality data compressor.
+
+licenses(["notice"])  # BSD derivative
+
+cc_library(
+    name = "bz2lib",
+    srcs = [
+        "blocksort.c",
+        "bzlib.c",
+        "bzlib_private.h",
+        "compress.c",
+        "crctable.c",
+        "decompress.c",
+        "huffman.c",
+        "randtable.c",
+    ],
+    hdrs = [
+        "bzlib.h",
+    ],
+    includes = ["."],
+    visibility = ["//visibility:public"],
+)

--- a/BUILD.zlib
+++ b/BUILD.zlib
@@ -1,0 +1,46 @@
+# Description:
+#   zlib is a general purpose data compression library.
+
+licenses(["notice"])  # BSD/MIT-like license (for zlib)
+
+cc_library(
+    name = "zlib",
+    srcs = [
+        "adler32.c",
+        "compress.c",
+        "contrib/amd64/amd64-match.S",
+        "crc32.c",
+        "crc32.h",
+        "deflate.c",
+        "deflate.h",
+        "gzclose.c",
+        "gzguts.h",
+        "gzlib.c",
+        "gzread.c",
+        "gzwrite.c",
+        "infback.c",
+        "inffast.c",
+        "inffast.h",
+        "inffixed.h",
+        "inflate.c",
+        "inflate.h",
+        "inftrees.c",
+        "inftrees.h",
+        "trees.c",
+        "trees.h",
+        "uncompr.c",
+        "zconf.h",
+        "zutil.c",
+        "zutil.h",
+    ],
+    hdrs = [
+        "zlib.h",
+    ],
+    copts = [
+        "-DUNALIGNED_OK",
+        "-DEXPAND_INSERT_STRING",
+        "-Wno-implicit-function-declaration",
+    ],
+    includes = ["."],
+    visibility = ["//visibility:public"],
+)

--- a/boost/boost.bzl
+++ b/boost/boost.bzl
@@ -66,10 +66,29 @@ def boost_library(name, defines=None, includes=None, hdrs=None, srcs=None,
   )
 
 def boost_deps():
-  native.new_http_archive(
-    name = "boost",
-    url = "https://dl.bintray.com/boostorg/release/1.63.0/source/boost_1_63_0.tar.gz",
-    build_file = "@com_github_nelhage_boost//:BUILD.boost",
-    strip_prefix = "boost_1_63_0/",
-    sha256 = "fe34a4e119798e10b8cc9e565b3b0284e9fd3977ec8a1b19586ad1dec397088b",
-  )
+  if "net_zlib_zlib" not in native.existing_rules():
+    native.new_http_archive(
+        name = "net_zlib_zlib",
+        build_file = "@com_github_nelhage_boost//:BUILD.zlib",
+        sha256 = "c3e5e9fdd5004dcb542feda5ee4f0ff0744628baf8ed2dd5d66f8ca1197cb1a1",
+        strip_prefix = "zlib-1.2.11",
+        url = "https://zlib.net/zlib-1.2.11.tar.gz",
+    )
+
+  if "org_bzip_bzip2" not in native.existing_rules():
+    native.new_http_archive(
+        name = "org_bzip_bzip2",
+        build_file = "@com_github_nelhage_boost//:BUILD.bzip2",
+        sha256 = "a2848f34fcd5d6cf47def00461fcb528a0484d8edef8208d6d2e2909dc61d9cd",
+        strip_prefix = "bzip2-1.0.6",
+        url = "http://www.bzip.org/1.0.6/bzip2-1.0.6.tar.gz",
+    )
+
+  if "boost" not in native.existing_rules():
+    native.new_http_archive(
+      name = "boost",
+      url = "https://dl.bintray.com/boostorg/release/1.63.0/source/boost_1_63_0.tar.gz",
+      build_file = "@com_github_nelhage_boost//:BUILD.boost",
+      strip_prefix = "boost_1_63_0/",
+      sha256 = "fe34a4e119798e10b8cc9e565b3b0284e9fd3977ec8a1b19586ad1dec397088b",
+    )

--- a/test/BUILD
+++ b/test/BUILD
@@ -30,6 +30,16 @@ cc_test(
 )
 
 cc_test(
+    name = "iostreams_test",
+    size = "small",
+    srcs = ["iostreams_test.cc"],
+    deps = [
+        "@boost//:iostreams",
+        "@boost//:test",
+    ],
+)
+
+cc_test(
     name = "random_test",
     size = "small",
     srcs = ["random_test.cc"],

--- a/test/WORKSPACE
+++ b/test/WORKSPACE
@@ -5,16 +5,15 @@ local_repository(
 
 load("@com_github_nelhage_boost//:boost/boost.bzl", "boost_deps")
 
-boost_deps()
-
 # boost_deps() will re-download the tarball every time BUILD.boost
 # changes, which is frustrating for doing development. Download it
-# yourself, uncomment the below, comment out the `boost_deps() call,
-# and change the path as appropriate for a faster iteration cycle on
-# changes.
+# yourself, uncomment the below and change the path as appropriate
+# for a faster iteration cycle on changes.
 #
 # new_local_repository(
 #     name = "boost",
 #     build_file = "@com_github_nelhage_boost//:BUILD.boost",
 #     path = "/home/nelhage/code/boost_1_63_0/",
 # )
+
+boost_deps()

--- a/test/iostreams_test.cc
+++ b/test/iostreams_test.cc
@@ -1,0 +1,23 @@
+#define BOOST_TEST_MODULE iostreams_test
+#include <boost/iostreams/device/back_inserter.hpp>
+#include <boost/iostreams/filter/gzip.hpp>
+#include <boost/iostreams/filtering_stream.hpp>
+#include <boost/test/included/unit_test.hpp>
+
+BOOST_AUTO_TEST_CASE( test_iostreams )
+{
+  std::string uncompressed ("hello");
+  std::string compressed;
+  std::string expected ("\x1f\x8b\x08\x00\x00\x00\x00\x00\x04\xff\xcb\x48\xcd\xc9\xc9\x07\x00\x86\xa6\x10\x36\x05\x00\x00\x00", 25);
+
+  boost::iostreams::filtering_ostream out;
+  out.push(
+      boost::iostreams::gzip_compressor(boost::iostreams::zlib::best_speed));
+  out.push(boost::iostreams::back_inserter(compressed));
+  boost::iostreams::write(out,
+                          reinterpret_cast<const char*>(uncompressed.data()),
+                          uncompressed.size());
+  boost::iostreams::close(out);
+
+  BOOST_TEST(compressed == expected);
+}


### PR DESCRIPTION
- Add zlib and bzip2 to the boost_deps() macro.
- Check existing_rules to avoid repo redefinition, as recommended here:
  https://groups.google.com/d/msg/bazel-discuss/EBeFucaAg3A/5KG4uaTiBwAJ
- Adjust test/WORKSPACE to always use boost_deps(), but to optionally
  override the boost archive.