### PR TITLE
Add a :numeric_conversion target

### DIFF
--- a/BUILD.boost
+++ b/BUILD.boost
@@ -410,7 +410,7 @@ boost_library(
         ":math",
         ":mpl",
         ":noncopyable",
-        ":numeric",
+        ":numeric_conversion",
         ":range",
         ":static_assert",
         ":throw_exception",
@@ -472,6 +472,23 @@ boost_library(
     name = "none",
     hdrs = [
         "boost/none_t.hpp",
+    ],
+)
+
+boost_library(
+    name = "numeric_conversion",
+    hdrs = glob([
+        "boost/numeric/conversion/**/*.hpp",
+    ]),
+    deps = [
+        ":config",
+        ":detail",
+        ":integer",
+        ":limits",
+        ":mpl",
+        ":throw_exception",
+        ":type",
+        ":type_traits",
     ],
 )
 
@@ -952,7 +969,7 @@ boost_library(
         ":iterator",
         ":limits",
         ":mpl",
-        ":numeric",
+        ":numeric_conversion",
         ":optional",
         ":preprocessor",
         ":smart_ptr",

--- a/test/BUILD
+++ b/test/BUILD
@@ -40,6 +40,16 @@ cc_test(
 )
 
 cc_test(
+    name = "numeric_conversion_test",
+    size = "small",
+    srcs = ["numeric_conversion_test.cc"],
+    deps = [
+        "@boost//:numeric_conversion",
+        "@boost//:test",
+    ],
+)
+
+cc_test(
     name = "random_test",
     size = "small",
     srcs = ["random_test.cc"],

--- a/test/numeric_conversion_test.cc
+++ b/test/numeric_conversion_test.cc
@@ -1,0 +1,10 @@
+#define BOOST_TEST_MODULE numeric_conversion_test
+#include <boost/numeric/conversion/cast.hpp>
+#include <boost/test/included/unit_test.hpp>
+
+BOOST_AUTO_TEST_CASE( test_numeric_conversion )
+{
+  short a = 42;
+  int b = 42;
+  BOOST_TEST(boost::numeric_cast<int>(a) == b);
+}


### PR DESCRIPTION
This better models the boost::numeric packages, which are split into:
- Numeric Conversion
- Interval Arithmetic
- Odeint
- uBLAS

I haven't deleted :numeric because I didn't want to break anyone
unnecessarily, but I can adjust the PR if you would prefer that.