### PR TITLE
Mask warning in :filesystem

### DIFF
--- a/BUILD.boost
+++ b/BUILD.boost
@@ -231,6 +231,9 @@ boost_library(
 
 boost_library(
     name = "filesystem",
+    copts = [
+        "-Wno-deprecated-declarations",
+    ],
     deps = [
         ":config",
         ":functional",


### PR DESCRIPTION
The warning occurs with gcc 6.3.0 due to the use of the deprecated
readdir_r.