### PR TITLE
Don't use :test from the tests

### DIFF
--- a/BUILD.boost
+++ b/BUILD.boost
@@ -258,7 +258,7 @@ boost_library(
         ":detail",
         ":limits",
         ":optional",
-        ":shared_ptr",
+        ":smart_ptr",
         ":throw_exception",
         ":timer",
         ":utility",
@@ -285,6 +285,7 @@ boost_library(
     name = "functional",
     deps = [
         ":detail",
+        ":integer",
     ],
 )
 
@@ -345,6 +346,8 @@ boost_library(
     deps = [
         ":detail",
         ":static_assert",
+        ":type_traits",
+        ":utility",
     ],
 )
 
@@ -606,7 +609,10 @@ boost_library(
 boost_library(
     name = "ref",
     deps = [
+        ":config",
         ":core",
+        ":detail",
+        ":utility",
     ],
 )
 
@@ -873,6 +879,9 @@ boost_library(
 
 boost_library(
     name = "tuple",
+    deps = [
+        ":ref",
+    ],
 )
 
 boost_library(

--- a/test/BUILD
+++ b/test/BUILD
@@ -4,7 +4,6 @@ cc_test(
     srcs = ["bind_test.cc"],
     deps = [
         "@boost//:bind",
-        "@boost//:test",
     ],
 )
 
@@ -14,7 +13,6 @@ cc_test(
     srcs = ["circular_buffer_test.cc"],
     deps = [
         "@boost//:circular_buffer",
-        "@boost//:test",
     ],
 )
 
@@ -25,7 +23,6 @@ cc_test(
     copts = ["-Wno-unused-value"],
     deps = [
         "@boost//:format",
-        "@boost//:test",
     ],
 )
 
@@ -35,7 +32,6 @@ cc_test(
     srcs = ["iostreams_test.cc"],
     deps = [
         "@boost//:iostreams",
-        "@boost//:test",
     ],
 )
 
@@ -45,7 +41,6 @@ cc_test(
     srcs = ["numeric_conversion_test.cc"],
     deps = [
         "@boost//:numeric_conversion",
-        "@boost//:test",
     ],
 )
 
@@ -55,7 +50,6 @@ cc_test(
     srcs = ["random_test.cc"],
     deps = [
         "@boost//:random",
-        "@boost//:test",
     ],
 )
 
@@ -65,7 +59,6 @@ cc_test(
     srcs = ["scope_exit_test.cc"],
     deps = [
         "@boost//:scope_exit",
-        "@boost//:test",
     ],
 )
 
@@ -75,7 +68,6 @@ cc_test(
     srcs = ["signals2_test.cc"],
     deps = [
         "@boost//:signals2",
-        "@boost//:test",
     ],
 )
 
@@ -92,7 +84,6 @@ cc_test(
     size = "small",
     srcs = ["thread_test.cc"],
     deps = [
-        "@boost//:test",
         "@boost//:thread",
     ],
 )
@@ -102,7 +93,6 @@ cc_test(
     size = "small",
     srcs = ["tokenizer_test.cc"],
     deps = [
-        "@boost//:test",
         "@boost//:tokenizer",
     ],
 )
@@ -112,7 +102,6 @@ cc_test(
     size = "small",
     srcs = ["unordered_test.cc"],
     deps = [
-        "@boost//:test",
         "@boost//:unordered",
     ],
 )

--- a/test/bind_test.cc
+++ b/test/bind_test.cc
@@ -1,13 +1,15 @@
-#define BOOST_TEST_MODULE bind_test
 #include <boost/bind.hpp>
-#include <boost/test/included/unit_test.hpp>
 
 int f(int a, int b)
 {
   return a + b;
 }
 
-BOOST_AUTO_TEST_CASE( test_bind )
+int main()
 {
-  BOOST_TEST(boost::bind(f, 1, 2)() == 3);
+  if (boost::bind(f, 1, 2)() != 3) {
+    return 1;
+  }
+
+  return 0;
 }

--- a/test/circular_buffer_test.cc
+++ b/test/circular_buffer_test.cc
@@ -1,10 +1,13 @@
-#define BOOST_TEST_MODULE circular_buffer_test
 #include <boost/circular_buffer.hpp>
-#include <boost/test/included/unit_test.hpp>
 
-BOOST_AUTO_TEST_CASE( test_circular_buffer )
+int main()
 {
   boost::circular_buffer<int> cb(1);
   cb.push_back(1);
-  BOOST_TEST(cb[0] == 1);
+
+  if (cb[0] != 1) {
+    return 1;
+  }
+
+  return 0;
 }

--- a/test/format_test.cc
+++ b/test/format_test.cc
@@ -1,8 +1,10 @@
-#define BOOST_TEST_MODULE format_test
 #include <boost/format.hpp>
-#include <boost/test/included/unit_test.hpp>
 
-BOOST_AUTO_TEST_CASE( test_format )
+int main()
 {
-  BOOST_TEST((boost::format("hello %d") % 1).str() == "hello 1");
+  if ((boost::format("hello %d") % 1).str() != "hello 1") {
+    return 1;
+  }
+
+  return 0;
 }

--- a/test/iostreams_test.cc
+++ b/test/iostreams_test.cc
@@ -1,10 +1,8 @@
-#define BOOST_TEST_MODULE iostreams_test
 #include <boost/iostreams/device/back_inserter.hpp>
 #include <boost/iostreams/filter/gzip.hpp>
 #include <boost/iostreams/filtering_stream.hpp>
-#include <boost/test/included/unit_test.hpp>
 
-BOOST_AUTO_TEST_CASE( test_iostreams )
+int main()
 {
   std::string uncompressed ("hello");
   std::string compressed;
@@ -19,5 +17,9 @@ BOOST_AUTO_TEST_CASE( test_iostreams )
                           uncompressed.size());
   boost::iostreams::close(out);
 
-  BOOST_TEST(compressed == expected);
+  if (compressed != expected) {
+    return 1;
+  }
+
+  return 0;
 }

--- a/test/numeric_conversion_test.cc
+++ b/test/numeric_conversion_test.cc
@@ -1,10 +1,13 @@
-#define BOOST_TEST_MODULE numeric_conversion_test
 #include <boost/numeric/conversion/cast.hpp>
-#include <boost/test/included/unit_test.hpp>
 
-BOOST_AUTO_TEST_CASE( test_numeric_conversion )
+int main()
 {
   short a = 42;
   int b = 42;
-  BOOST_TEST(boost::numeric_cast<int>(a) == b);
+
+  if (boost::numeric_cast<int>(a) != b) {
+    return 1;
+  }
+
+  return 0;
 }

--- a/test/random_test.cc
+++ b/test/random_test.cc
@@ -1,11 +1,14 @@
-#define BOOST_TEST_MODULE random_test
 #include <boost/random/mersenne_twister.hpp>
 #include <boost/random/uniform_int_distribution.hpp>
-#include <boost/test/included/unit_test.hpp>
 
-BOOST_AUTO_TEST_CASE( test_random )
+int main()
 {
   boost::random::mt19937 gen;
   boost::random::uniform_int_distribution<> dist(1, 6);
-  BOOST_TEST(dist(gen) <= 6);
+
+  if (dist(gen) > 6) {
+    return 1;
+  }
+
+  return 0;
 }

--- a/test/scope_exit_test.cc
+++ b/test/scope_exit_test.cc
@@ -1,6 +1,4 @@
-#define BOOST_TEST_MODULE scope_exit_test
 #include <boost/scope_exit.hpp>
-#include <boost/test/included/unit_test.hpp>
 
 void f(bool *flag)
 {
@@ -10,9 +8,14 @@ void f(bool *flag)
   } BOOST_SCOPE_EXIT_END
 }
 
-BOOST_AUTO_TEST_CASE( test_scope_exit )
+int main()
 {
   bool flag = false;
   f(&flag);
-  BOOST_TEST(flag);
+
+  if (!flag) {
+    return 1;
+  }
+
+  return 0;
 }

--- a/test/signals2_test.cc
+++ b/test/signals2_test.cc
@@ -1,6 +1,4 @@
-#define BOOST_TEST_MODULE signals2_test
 #include <boost/signals2.hpp>
-#include <boost/test/included/unit_test.hpp>
 
 class FlagSetter
 {
@@ -15,7 +13,7 @@ class FlagSetter
   bool *flag;
 };
 
-BOOST_AUTO_TEST_CASE( test_signals2 )
+int main()
 {
   bool called = false;
 
@@ -23,7 +21,11 @@ BOOST_AUTO_TEST_CASE( test_signals2 )
   FlagSetter fs (&called);
   sig.connect(fs);
 
-  BOOST_TEST(!called);
   sig();
-  BOOST_TEST(called);
+
+  if (!called) {
+    return 1;
+  }
+
+  return 0;
 }

--- a/test/thread_test.cc
+++ b/test/thread_test.cc
@@ -1,13 +1,12 @@
-#define BOOST_TEST_MODULE thread_test
-#include <boost/test/included/unit_test.hpp>
 #include <boost/thread.hpp>
 
 void thread()
 {
 }
 
-BOOST_AUTO_TEST_CASE( test_thread )
+int main()
 {
   boost::thread t{thread};
   t.join();
+  return 0;
 }

--- a/test/tokenizer_test.cc
+++ b/test/tokenizer_test.cc
@@ -1,11 +1,14 @@
-#define BOOST_TEST_MODULE tokenizer_test
 #include <string>
 #include <boost/tokenizer.hpp>
-#include <boost/test/included/unit_test.hpp>
 
-BOOST_AUTO_TEST_CASE( test_tokenizer )
+int main()
 {
   std::string s = "foo bar";
   boost::tokenizer<> tok(s);
-  BOOST_TEST(*(tok.begin()) == "foo");
+
+  if (*(tok.begin()) != "foo") {
+    return 1;
+  }
+
+  return 0;
 }

--- a/test/unordered_test.cc
+++ b/test/unordered_test.cc
@@ -1,13 +1,15 @@
-#define BOOST_TEST_MODULE unordered_test
 #include <string>
 #include <boost/unordered_map.hpp>
-#include <boost/test/included/unit_test.hpp>
 
-BOOST_AUTO_TEST_CASE( test_unordered )
+int main()
 {
   boost::unordered_map<std::string, int> m;
 
   m["one"] = 1;
 
-  BOOST_TEST(m.at("one") == 1);
+  if (m.at("one") != 1) {
+    return 1;
+  }
+
+  return 0;
 }


### PR DESCRIPTION
This can mask missing dependencies because :test depends on so much
of Boost.

Also add the missing dependencies that are no longer masked.