### PR TITLE
Avoid double definition of non-POD data types when using boost test

### DIFF
--- a/BUILD.boost
+++ b/BUILD.boost
@@ -1178,11 +1178,7 @@ boost_library(
 
 boost_library(
     name = "test",
-    exclude_src = [
-        "libs/test/src/unit_test_main.cpp",
-        "libs/test/src/test_main.cpp",
-        "libs/test/src/cpp_main.cpp",
-    ],
+    exclude_src = glob(["libs/test/src/*.cpp"]),
     deps = [
         ":algorithm",
         ":assert",

--- a/BUILD.boost
+++ b/BUILD.boost
@@ -753,7 +753,6 @@ boost_library(
         ":shared_ptr",
         ":static_assert",
         ":system",
-        ":test",
         ":throw_exception",
         ":timer",
         ":tuple",


### PR DESCRIPTION
## The problem

This is a somewhat subtle one: Before this patch, when building unit tests using Boost Test and these Bazel rules with dynamic linking (which is the default and what this project is using), both the unit test file that would contain definitions of the strings in unit_test_parameters.ipp, e.g. _ZN5boost9unit_test14runtime_config14AUTO_START_DBGB5cxx11E
 This is not great, and can lead to double-free errors as the dynamic linker merges the symbols into one address and both modules do their cleanup of the strings after the test has finished executing.

Sadly, I don't know of a way to write a test that reliably crashes before this patch (I did not try using ASan because it's not necessarily always available), but the problem can be seen by running nm on the built executables (the shared libs can be found using lld on the test executable).

## The fix

Don't compile anything as part of the boost test library. See http://www.boost.org/doc/libs/1_62_0/libs/test/doc/html/boost_test/usage_variants.html There are three ways of using Boost Test: As an header only library, with static linking or dynamic linking. Currently, test.cc uses the header only variant. This patch takes the header-only approach all the way. It's not straight forward in Bazel because the dynamic version requires an additional preprocessor flag, and I'm not sure how to make Bazel add that flag only when linking dynamically (I think it always reuses .o files when linking statically and dynamically).
