### PR TITLE
Added tribool build rule and test

### DIFF
--- a/BUILD.boost
+++ b/BUILD.boost
@@ -1030,6 +1030,18 @@ boost_library(
 )
 
 boost_library(
+    name = "tribool",
+    hdrs = [
+        "boost/logic/tribool.hpp",
+        "boost/logic/tribool_fwd.hpp"
+    ],
+    deps = [
+        ":config",
+        ":detail",
+    ],
+)
+
+boost_library(
     name = "type",
     deps = [
         ":core",

--- a/test/BUILD
+++ b/test/BUILD
@@ -234,6 +234,15 @@ cc_test(
 )
 
 cc_test(
+    name = "tribool_test",
+    size = "small",
+    srcs = ["tribool_test.cc"],
+    deps = [
+        "@boost//:tribool",
+    ],
+)
+
+cc_test(
     name = "unordered_test",
     size = "small",
     srcs = ["unordered_test.cc"],

--- a/test/tribool_test.cc
+++ b/test/tribool_test.cc
@@ -1,0 +1,15 @@
+#include <boost/logic/tribool.hpp>
+
+int main()
+{
+  boost::logic::tribool a(false);
+
+  if (a == true) {
+    return 1;
+  } else if(a == false) {
+      return 0;
+  } else {
+      return 2;
+  }
+
+}


### PR DESCRIPTION
This PR adds a build rule for the `boost::logic::tribool`.