### PR TITLE
Build liblzma with -std=c99

### DIFF
--- a/BUILD.lzma
+++ b/BUILD.lzma
@@ -96,6 +96,7 @@ cc_library(
         "src/liblzma/simple/x86.c",
     ],
     hdrs = glob(["src/**/*.h"]) + ["config.h"],
+    copts = ["-std=c99"],
     defines = [
         "HAVE_CONFIG_H",
     ],


### PR DESCRIPTION
This fixes #48 (Build fails with gcc 4.8).

However, gcc 4.8 is pretty old (2015), and any version later than 5.1 (also 2015) supports C99 by default. I'm about to upgrade myself, so feel free to reject this PR if there's a risk of breakage.