### PR TITLE
Build support for boost.context and boost.fiber.

### DIFF
--- a/BUILD.boost
+++ b/BUILD.boost
@@ -42,6 +42,9 @@ cc_library(
     }) +  [
         "libs/context/src/execution_context.cpp"
     ],
+    deps = [
+        ":config"
+    ],
     visibility=["//visibility:public"]
 )
 
@@ -86,6 +89,7 @@ cc_library(
     }),
     deps = [
         ":context",
+        ":intrusive_ptr",
         ":filesystem"
     ],
     linkopts = select({

--- a/BUILD.boost
+++ b/BUILD.boost
@@ -1,4 +1,101 @@
-load("@com_github_nelhage_rules_boost//:boost/boost.bzl", "boost_library")
+load("@com_github_nelhage_rules_boost//:boost/boost.bzl", "boost_library", "includes_list", "hdr_list")
+
+config_setting(
+    name = 'linux_x86_64',
+    constraint_values = [
+        '@bazel_tools//platforms:linux',
+        '@bazel_tools//platforms:x86_64'
+    ]
+)
+
+config_setting(
+    name = 'windows_x86_64',
+    constraint_values = [
+        '@bazel_tools//platforms:windows',
+        '@bazel_tools//platforms:x86_64'
+    ]
+)
+
+BOOST_CTX_ASM_SOURCES = select({
+    ":linux_x86_64": [
+        "libs/context/src/asm/jump_x86_64_sysv_elf_gas.S",
+        "libs/context/src/asm/make_x86_64_sysv_elf_gas.S",
+        "libs/context/src/asm/ontop_x86_64_sysv_elf_gas.S"],
+    ":windows_x86_64": [
+        "libs/context/src/asm/make_x86_64_ms_pe_masm.asm",
+        "libs/context/src/asm/jump_x86_64_ms_pe_masm.asm",
+        "libs/context/src/asm/ontop_x86_64_ms_pe_masm.asm"
+    ]
+})
+
+cc_library(
+    name = "context",
+    includes = includes_list("context"),
+    hdrs = hdr_list("context"),
+    srcs = BOOST_CTX_ASM_SOURCES + select({
+        ":linux_x86_64": [
+            "libs/context/src/posix/stack_traits.cpp"
+        ],
+        ":windows_x86_64": [
+            "libs/context/src/windows/stack_traits.cpp"
+        ]
+    }) +  [
+        "libs/context/src/execution_context.cpp"
+    ],
+    visibility=["//visibility:public"]
+)
+
+BOOST_FIBER_NUMA_SRCS = select({
+    ":linux_x86_64": [
+        "libs/fiber/src/numa/linux/pin_thread.cpp",
+        "libs/fiber/src/numa/linux/topology.cpp"
+    ],
+    ":windows_x86_64": [
+        "libs/fiber/src/numa/windows/pin_thread.cpp",
+        "libs/fiber/src/numa/windows/topology.cpp"
+    ]
+})
+
+cc_library(
+    name = "fiber",
+    includes = includes_list("fiber"),
+    hdrs = hdr_list("fiber"),
+    srcs = BOOST_FIBER_NUMA_SRCS + [
+        "libs/fiber/src/algo/algorithm.cpp",
+        "libs/fiber/src/algo/round_robin.cpp",
+        "libs/fiber/src/algo/shared_work.cpp",
+        "libs/fiber/src/algo/work_stealing.cpp",
+        "libs/fiber/src/algo/numa/work_stealing.cpp",
+        "libs/fiber/src/barrier.cpp",
+        "libs/fiber/src/condition_variable.cpp",
+        "libs/fiber/src/context.cpp",
+        "libs/fiber/src/fiber.cpp",
+        "libs/fiber/src/future.cpp",
+        "libs/fiber/src/mutex.cpp",
+        "libs/fiber/src/properties.cpp",
+        "libs/fiber/src/recursive_mutex.cpp",
+        "libs/fiber/src/recursive_timed_mutex.cpp",
+        "libs/fiber/src/timed_mutex.cpp",
+        "libs/fiber/src/scheduler.cpp"
+    ],
+    copts = select({
+        ":windows_x86_64": [
+            "/D_WIN32_WINNT=0x0601"
+        ],
+        "//conditions:default": []
+    }),
+    deps = [
+        ":context",
+        ":filesystem"
+    ],
+    linkopts = select({
+        ":linux_x86_64": [
+            "-lpthread"
+        ],
+        "//conditions:default": []    
+    }),
+    visibility=["//visibility:public"]
+)
 
 boost_library(
     name = "algorithm",

--- a/BUILD.boost
+++ b/BUILD.boost
@@ -43,7 +43,11 @@ cc_library(
         "libs/context/src/execution_context.cpp"
     ],
     deps = [
-        ":config"
+        ":config",
+        ":detail",
+        ":assert",
+        ":cstdint",
+        ":intrusive_ptr"
     ],
     visibility=["//visibility:public"]
 )
@@ -88,7 +92,11 @@ cc_library(
         "//conditions:default": []
     }),
     deps = [
+        ":pool",
+        ":format",
         ":context",
+        ":algorithm",
+        ":intrusive",
         ":intrusive_ptr",
         ":filesystem"
     ],
@@ -99,6 +107,10 @@ cc_library(
         "//conditions:default": []    
     }),
     visibility=["//visibility:public"]
+)
+
+boost_library(
+    name = "pool"
 )
 
 boost_library(

--- a/test/BUILD
+++ b/test/BUILD
@@ -81,6 +81,15 @@ cc_test(
 )
 
 cc_test(
+    name = "context_test",
+    size = "small",
+    srcs = ["context_test.cc"],
+    deps = [
+        "@boost//:context",
+    ],
+)
+
+cc_test(
     name = "dynamic_bitset_test",
     size = "small",
     srcs = ["dynamic_bitset_test.cc"],
@@ -96,6 +105,15 @@ cc_test(
     deps = [
         "@boost//:endian",
         "@boost//:static_assert",
+    ],
+)
+
+cc_test(
+    name = "fiber_test",
+    size = "small",
+    srcs = ["fiber_test.cc"],
+    deps = [
+        "@boost//:fiber",
     ],
 )
 

--- a/test/context_test.cc
+++ b/test/context_test.cc
@@ -1,0 +1,33 @@
+// Example originates from the boost.context repo: 
+// https://github.com/boostorg/context/blob/develop/example/callcc/fibonacci.cpp
+
+#include <cstdlib>
+#include <iostream>
+#include <memory>
+
+#include <boost/context/continuation.hpp>
+
+namespace ctx = boost::context;
+
+int main() {
+    int a;
+    ctx::continuation c=ctx::callcc(
+        [&a](ctx::continuation && c){
+            a=0;
+            int b=1;
+            for(;;){
+                c=c.resume();
+                int next=a+b;
+                a=b;
+                b=next;
+            }
+            return std::move( c);
+        });
+    for ( int j = 0; j < 10; ++j) {
+        std::cout << a << " ";
+        c=c.resume();
+    }
+    std::cout << std::endl;
+    std::cout << "main: done" << std::endl;
+    return EXIT_SUCCESS;
+}

--- a/test/fiber_test.cc
+++ b/test/fiber_test.cc
@@ -1,0 +1,36 @@
+// Example originates from the boost.fiber repo: 
+// https://github.com/boostorg/fiber/blob/develop/examples/simple.cpp
+
+#include <cstdlib>
+#include <iostream>
+#include <memory>
+#include <string>
+#include <thread>
+
+#include <boost/intrusive_ptr.hpp>
+
+#include <boost/fiber/all.hpp>
+
+inline
+void fn( std::string const& str, int n) {
+	for ( int i = 0; i < n; ++i) {
+		std::cout << i << ": " << str << std::endl;
+		boost::this_fiber::yield();
+	}
+}
+
+int main() {
+    try {
+        boost::fibers::fiber f1( fn, "abc", 5);
+        std::cerr << "f1 : " << f1.get_id() << std::endl;
+        f1.join();
+        std::cout << "done." << std::endl;
+
+        return EXIT_SUCCESS;
+    } catch ( std::exception const& e) {
+        std::cerr << "exception: " << e.what() << std::endl;
+    } catch (...) {
+        std::cerr << "unhandled exception" << std::endl;
+    }
+	return EXIT_FAILURE;
+}


### PR DESCRIPTION
Just added basic support for building those two libraries on linux. We have to modify the rule/macro definition of boost_library in order to be able to build boost on multiple platforms. 