### PR TITLE
Add coroutine, rational and multiprecision

### DIFF
--- a/BUILD.boost
+++ b/BUILD.boost
@@ -748,6 +748,22 @@ boost_library(
 )
 
 boost_library(
+    name = "multiprecision",
+    deps = [
+        ":config",
+        ":cstdint",
+        ":lexical_cast",
+        ":math",
+        ":mpl",
+        ":predef",
+        ":rational",
+        ":throw_exception",
+        ":type_traits",
+        ":utility",
+    ],
+)
+
+boost_library(
     name = "noncopyable",
 )
 

--- a/BUILD.boost
+++ b/BUILD.boost
@@ -568,6 +568,13 @@ boost_library(
 )
 
 boost_library(
+    name = "icl",
+    deps = [
+        ":concept_check",
+    ],
+)
+
+boost_library(
     name = "is_placeholder",
 )
 

--- a/BUILD.boost
+++ b/BUILD.boost
@@ -344,6 +344,30 @@ boost_library(
     ],
 )
 
+BOOST_CORO_SRCS = select({
+    ":linux_x86_64": [
+        "libs/coroutine/src/posix/stack_traits.cpp",
+    ],
+    ":windows_x86_64": [
+        "libs/coroutine/src/windows/stack_traits.cpp",
+    ],
+})
+
+boost_library(
+    name = "coroutine",
+    srcs = BOOST_CORO_SRCS + [
+        "libs/coroutine/src/detail/coroutine_context.cpp",
+        ],
+    deps = [
+        ":config",
+        ":context",
+        ":move",
+        ":range",
+        ":system",
+        ":thread",
+    ],
+)
+
 boost_library(
     name = "cstdint",
 )

--- a/BUILD.boost
+++ b/BUILD.boost
@@ -609,7 +609,12 @@ boost_library(
     name = "iterator",
     hdrs = [
         "boost/function_output_iterator.hpp",
+        "boost/generator_iterator.hpp",
+        "boost/indirect_reference.hpp",
+        "boost/iterator_adaptors.hpp",
+        "boost/next_prior.hpp",
         "boost/pointee.hpp",
+        "boost/shared_container_iterator.hpp",
     ],
     deps = [
         ":detail",

--- a/BUILD.boost
+++ b/BUILD.boost
@@ -942,6 +942,22 @@ boost_library(
 )
 
 boost_library(
+    name = "rational",
+    deps = [
+        ":assert",
+        ":call_traits",
+        ":config",
+        ":detail",
+        ":integer",
+        ":operators",
+        ":static_assert",
+        ":throw_exception",
+        ":type_traits",
+        ":utility",
+    ],
+)
+
+boost_library(
     name = "ref",
     deps = [
         ":config",

--- a/test/BUILD
+++ b/test/BUILD
@@ -182,6 +182,15 @@ cc_test(
 )
 
 cc_test(
+    name = "multiprecision_test",
+    size = "small",
+    srcs = ["multiprecision_test.cc"],
+    deps = [
+        "@boost//:multiprecision",
+    ],
+)
+
+cc_test(
     name = "numeric_conversion_test",
     size = "small",
     srcs = ["numeric_conversion_test.cc"],

--- a/test/BUILD
+++ b/test/BUILD
@@ -99,6 +99,15 @@ cc_test(
 )
 
 cc_test(
+    name = "coroutine_test",
+    size = "small",
+    srcs = ["coroutine_test.cc"],
+    deps = [
+        "@boost//:coroutine",
+    ]
+)
+
+cc_test(
     name = "dynamic_bitset_test",
     size = "small",
     srcs = ["dynamic_bitset_test.cc"],

--- a/test/BUILD
+++ b/test/BUILD
@@ -236,6 +236,15 @@ cc_test(
 )
 
 cc_test(
+    name = "rational_test",
+    size = "small",
+    srcs = ["rational_test.cc"],
+    deps = [
+        "@boost//:rational",
+    ],
+)
+
+cc_test(
     name = "scope_exit_test",
     size = "small",
     srcs = ["scope_exit_test.cc"],

--- a/test/BUILD
+++ b/test/BUILD
@@ -164,6 +164,15 @@ cc_test(
 )
 
 cc_test(
+    name = "icl_test",
+    size = "small",
+    srcs = ["icl_test.cc"],
+    deps = [
+        "@boost//:icl",
+    ],
+)
+
+cc_test(
     name = "iostreams_test",
     size = "small",
     srcs = ["iostreams_test.cc"],

--- a/test/coroutine_test.cc
+++ b/test/coroutine_test.cc
@@ -1,0 +1,6 @@
+#include <boost/coroutine/all.hpp>
+
+int main()
+{
+  return 0;
+}

--- a/test/icl_test.cc
+++ b/test/icl_test.cc
@@ -1,0 +1,6 @@
+#include <boost/icl/closed_interval.hpp>
+
+int main()
+{
+  return 0;
+}

--- a/test/multiprecision_test.cc
+++ b/test/multiprecision_test.cc
@@ -1,0 +1,12 @@
+#include <boost/multiprecision/cpp_int.hpp>
+
+int main()
+{
+  boost::multiprecision::uint128_t a(123);
+  int b = 123;
+  if (a != b) {
+    return 1;
+  }
+
+  return 0;
+}

--- a/test/rational_test.cc
+++ b/test/rational_test.cc
@@ -1,0 +1,11 @@
+#include <boost/rational.hpp>
+
+int main()
+{
+  boost::rational<int> half(1,2);
+  if (boost::rational_cast<double>(half) != 0.5) {
+    return 1;
+  }
+
+  return 0;
+}


### PR DESCRIPTION
The test case for coroutine is not that great and the other ones are maybe not much better (I'm not deeply into boost, I just want to consume these libraries in bazel).

Hope this is enough to get the ball rolling on adding these to rules_boost.