### PR TITLE
type_traits depends on config.hpp

### DIFF
--- a/BUILD.boost
+++ b/BUILD.boost
@@ -1257,6 +1257,7 @@ boost_library(
         "boost/aligned_storage.hpp",
     ],
     deps = [
+        ":config",
         ":core",
         ":mpl",
         ":static_assert",


### PR DESCRIPTION
When using type_traits headers I get the error below.
Adding "@boost//:config" in my BUILD deps fixes the issue, but type_traits should really include it.

```
In file included from external/boost/boost/type_traits/is_base_of.hpp:12:
In file included from external/boost/boost/type_traits/is_base_and_derived.hpp:12:
external/boost/boost/type_traits/intrinsics.hpp:13:10: fatal error: 'boost/config.hpp' file not found
#include <boost/config.hpp>
         ^~~~~~~~~~~~~~~~~~
1 error generated.
```