### PR TITLE
Suppress stdout from ./configure

### DIFF
--- a/BUILD.lzma
+++ b/BUILD.lzma
@@ -8,7 +8,7 @@ genrule(
     outs = [
         "config.h",
     ],
-    cmd = "cd external/org_lzma_lzma && ./configure && cp config.h ../../$(location config.h)",
+    cmd = "cd external/org_lzma_lzma && ./configure > /dev/null && cp config.h ../../$(location config.h)",
     tools = [
         "configure",
         "src/liblzma/common/common.h",


### PR DESCRIPTION
This is recommended by the [Bazel
docs](https://docs.bazel.build/versions/master/be/general.html#general-advice):

> Do not write informational messages to stdout or stderr. While useful
> for debugging, this can easily become noise; a successful genrule
> should be silent. On the other hand, a failing genrule should emit
> good error messages.