### PR TITLE
Fix boost::locale build

### DIFF
--- a/BUILD.boost
+++ b/BUILD.boost
@@ -803,6 +803,32 @@ boost_library(
 
 boost_library(
     name = "locale",
+    srcs =
+        glob(
+            [
+                "libs/locale/src/**/*.cpp",
+                "libs/locale/src/**/*.hpp",
+                "libs/locale/src/**/*.ipp",
+            ],
+            exclude = [
+                "libs/locale/src/win32/*.cpp",
+                "libs/locale/src/icu/*.cpp",
+            ],
+        ),
+    copts = [
+        "-DBOOST_LOCALE_WITH_ICONV",
+        "-DBOOST_LOCALE_NO_WINAPI_BACKEND",
+        # boost::locale implementation uses deprecated auto_ptr
+        "-Wno-deprecated-declarations",
+    ],
+    deps = [
+        ":assert",
+        ":config",
+        ":cstdint",
+        ":smart_ptr",
+        ":thread",
+        ":unordered",
+    ],
 )
 
 boost_library(
@@ -819,7 +845,7 @@ boost_library(
         ":static_assert",
         ":type_traits",
         ":utility",
-    ]
+    ],
 )
 
 boost_library(
@@ -946,13 +972,13 @@ boost_library(
         "boost/numeric/odeint/**/*.hpp",
     ]),
     deps = [
+        ":fusion",
+        ":lexical_cast",
+        ":math",
+        ":multi_array",
         ":numeric",
         ":serialization",
         ":units",
-        ":fusion",
-        ":math",
-        ":lexical_cast",
-        ":multi_array",
     ],
 )
 
@@ -1305,13 +1331,13 @@ BOOST_STACKTRACE_SOURCES = select({
 boost_library(
     name = "stacktrace",
     srcs = BOOST_STACKTRACE_SOURCES,
-    exclude_src = ["libs/stacktrace/src/*.cpp"],
     defines = select({
         ":osx_x86_64": [
             "BOOST_STACKTRACE_GNU_SOURCE_NOT_REQUIRED",
         ],
         "//conditions:default": [],
     }),
+    exclude_src = ["libs/stacktrace/src/*.cpp"],
     linkopts = select({
         ":linux_x86_64": [
             "-lbacktrace -ldl",

--- a/test/BUILD
+++ b/test/BUILD
@@ -104,7 +104,7 @@ cc_test(
     srcs = ["compute_test.cc"],
     deps = [
         "@boost//:compute",
-    ]
+    ],
 )
 
 cc_test(
@@ -113,7 +113,7 @@ cc_test(
     srcs = ["coroutine_test.cc"],
     deps = [
         "@boost//:coroutine",
-    ]
+    ],
 )
 
 cc_test(
@@ -128,7 +128,7 @@ cc_test(
 cc_test(
     name = "endian",
     size = "small",
-    srcs = [ "endian.cc" ],
+    srcs = ["endian.cc"],
     deps = [
         "@boost//:endian",
         "@boost//:static_assert",
@@ -411,5 +411,14 @@ cc_test(
     srcs = ["lockfree_test.cc"],
     deps = [
         "@boost//:lockfree",
+    ],
+)
+
+cc_test(
+    name = "locale_test",
+    size = "small",
+    srcs = ["locale_test.cc"],
+    deps = [
+        "@boost//:locale",
     ],
 )

--- a/test/locale_test.cc
+++ b/test/locale_test.cc
@@ -1,0 +1,15 @@
+#include <string>
+#include <iostream>
+
+#include <boost/locale/encoding.hpp>
+#include <boost/locale/encoding_utf.hpp>
+
+int main(int, char**) {
+    std::string utf8_string = boost::locale::conv::to_utf<char>
+        ("N""\xf6""el", "iso-8859-1");
+    if (utf8_string != "Nöel") {
+        std::cerr << "conversion failed!" << std::endl;
+        return 1;
+    }
+    return 0;
+}


### PR DESCRIPTION
Add missing source files and `-D` definitions. Add a minimal test.

fixes #86 