### PR TITLE
Use Starlark http_archive

### DIFF
--- a/boost/boost.bzl
+++ b/boost/boost.bzl
@@ -1,3 +1,5 @@
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
 include_pattern = "boost/%s/"
 
 hdrs_patterns = [
@@ -82,7 +84,7 @@ def boost_library(
 
 def boost_deps():
     if "net_zlib_zlib" not in native.existing_rules():
-        native.new_http_archive(
+        http_archive(
             name = "net_zlib_zlib",
             build_file = "@com_github_nelhage_rules_boost//:BUILD.zlib",
             sha256 = "c3e5e9fdd5004dcb542feda5ee4f0ff0744628baf8ed2dd5d66f8ca1197cb1a1",
@@ -94,7 +96,7 @@ def boost_deps():
         )
 
     if "org_bzip_bzip2" not in native.existing_rules():
-        native.new_http_archive(
+        http_archive(
             name = "org_bzip_bzip2",
             build_file = "@com_github_nelhage_rules_boost//:BUILD.bzip2",
             sha256 = "a2848f34fcd5d6cf47def00461fcb528a0484d8edef8208d6d2e2909dc61d9cd",
@@ -108,7 +110,7 @@ def boost_deps():
     SOURCEFORGE_MIRRORS = ["phoenixnap", "newcontinuum", "cfhcable", "superb-sea2", "cytranet", "iweb", "gigenet", "ayera", "astuteinternet", "pilotfiber", "svwh"]
 
     if "org_lzma_lzma" not in native.existing_rules():
-        native.new_http_archive(
+        http_archive(
             name = "org_lzma_lzma",
             build_file = "@com_github_nelhage_rules_boost//:BUILD.lzma",
             sha256 = "71928b357d0a09a12a4b4c5fafca8c31c19b0e7d3b8ebb19622e96f26dbf28cb",
@@ -120,7 +122,7 @@ def boost_deps():
         )
 
     if "boost" not in native.existing_rules():
-        native.new_http_archive(
+        http_archive(
             name = "boost",
             urls = [
                 "https://%s.dl.sourceforge.net/project/boost/boost/1.67.0/boost_1_67_0.tar.gz" % m


### PR DESCRIPTION
This replaces the native http_archive and new_http_archive rules. The
old rules will be disabled by default in a future version of Bazel
(possibly 0.20).