### PR TITLE
Update zlib.net url with https version

### DIFF
--- a/boost/boost.bzl
+++ b/boost/boost.bzl
@@ -91,7 +91,7 @@ def boost_deps():
             strip_prefix = "zlib-1.2.11",
             urls = [
                 "https://mirror.bazel.build/zlib.net/zlib-1.2.11.tar.gz",
-                "http://zlib.net/zlib-1.2.11.tar.gz",
+                "https://zlib.net/zlib-1.2.11.tar.gz",
             ],
         )
 


### PR DESCRIPTION
`https://zlib.net/zlib-1.2.11.tar.gz` works now and might be better than `http://zlib.net/zlib-1.2.11.tar.gz`.