### PR TITLE
Fix "utility" rule

### DIFF
--- a/BUILD.boost
+++ b/BUILD.boost
@@ -1572,6 +1572,7 @@ boost_library(
         ":detail",
         ":preprocessor",
         ":swap",
+        ":type_traits",
     ],
 )
 


### PR DESCRIPTION
One more dependency is found: `":type_traits"`.