### PR TITLE
Add headers and dependencies for @boost//:conversion

### DIFF
--- a/BUILD.boost
+++ b/BUILD.boost
@@ -411,6 +411,19 @@ boost_library(
 
 boost_library(
     name = "conversion",
+    hdrs = [
+        "boost/cast.hpp",
+        "boost/polymorphic_cast.hpp",
+        "boost/polymorphic_pointer_cast.hpp",
+        "boost/implicit_cast.hpp",
+        "boost/lexical_cast.hpp",
+    ],
+    deps = [
+        ":assert",
+        ":config",
+        ":throw_exception",
+        ":fusion",
+    ],
 )
 
 boost_library(


### PR DESCRIPTION
These are not found by the glob in `boost.bzl`.