### PR TITLE
clang 10.0.1 removed experimental/string_view

### DIFF
--- a/BUILD.boost
+++ b/BUILD.boost
@@ -250,6 +250,12 @@ boost_library(
 
 boost_library(
     name = "asio",
+    defines = select({
+        ":osx_x86_64": [
+            "BOOST_ASIO_DISABLE_STD_EXPERIMENTAL_STRING_VIEW",
+        ],
+        "//conditions:default": [],
+    }),
     linkopts = ["-lpthread"],
     deps = [
         ":bind",


### PR DESCRIPTION
More precisely, the include file is still there but it errors out compilation. So the build needs to explicitly disable using it.
Ideally, we'd want to check the exact compiler version but I'm not sure how to do that with bazel.