### PR TITLE
Boost.Spirit v3 (X3) requires Boost.Range.

### DIFF
--- a/BUILD.boost
+++ b/BUILD.boost
@@ -1397,6 +1397,7 @@ boost_library(
     name = "spirit",
     deps = [
         ":optional",
+        ":range",
         ":ref",
         ":utility",
     ],


### PR DESCRIPTION
Boost.Spirit contains what essentially amounts to a rewrite, called X3. This relies on Boost.Range.