### PR TITLE
Create initial presubmit config for Bazel CI

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -1,0 +1,26 @@
+---
+tasks:
+  ubuntu1604:
+    working_directory: test
+    build_targets:
+    - "..."
+    test_targets:
+    - "..."
+  ubuntu1804:
+    working_directory: test
+    build_targets:
+    - "..."
+    test_targets:
+    - "..."
+  macos:
+    working_directory: test
+    build_targets:
+    - "..."
+    test_targets:
+    - "..."
+  windows:
+    working_directory: test
+    build_targets:
+    - "..."
+    test_targets:
+    - "..."


### PR DESCRIPTION
This file is needed to use the Bazel CI pipeline at https://buildkite.com/bazel/rules-boost

It still requires more work by project maintainers (e.g. adding build flags). Please see the documentation about the configuration features: https://github.com/bazelbuild/continuous-integration/blob/master/buildkite/README.md#basic-syntax

Progress towards https://github.com/nelhage/rules_boost/issues/128