### PR TITLE
Added coroutine2 Library To BUILD.boost

### DIFF
--- a/BUILD.boost
+++ b/BUILD.boost
@@ -518,6 +518,20 @@ boost_library(
 )
 
 boost_library(
+    name = "coroutine2",
+    hdrs = glob([
+        "libs/coroutine2/include/**/*.hpp",
+        "libs/coroutine2/include/**/*.ipp",
+    ]),
+    deps = [
+        ":config",
+        ":assert",
+        ":context",
+        ":detail",
+    ],
+)
+
+boost_library(
     name = "crc",
     deps = [
         ":config",

--- a/test/BUILD
+++ b/test/BUILD
@@ -117,6 +117,15 @@ cc_test(
 )
 
 cc_test(
+    name = "coroutine2_test",
+    size = "small",
+    srcs = ["coroutine2_test.cc"],
+    deps = [
+        "@boost//:coroutine2",
+    ],
+)
+
+cc_test(
     name = "coroutine_test",
     size = "small",
     srcs = ["coroutine_test.cc"],

--- a/test/coroutine2_test.cc
+++ b/test/coroutine2_test.cc
@@ -1,0 +1,6 @@
+#include <boost/coroutine2/all.hpp>
+
+int main()
+{
+  return 0;
+}


### PR DESCRIPTION
Added a build rule for the `coroutine2` library, and added a test for it. I was unable to run the tests however. Is there a method documented somewhere for doing so? Running `bazel test //...` gave this error:
```
ERROR: /home/gareth/Downloads/rules_boost/test/BUILD:1:1: no such package '@boost//': The repository '@boost' could not be resolved and referenced by '//test:accumulators_test'
```