### PR TITLE
Add contract

### DIFF
--- a/BUILD.boost
+++ b/BUILD.boost
@@ -2008,3 +2008,30 @@ boost_library(
 boost_library(
     name = "sort",
 )
+
+boost_library(
+    name = "contract",
+    hdrs = [
+        "boost/contract_macro.hpp",
+    ],
+    deps = [
+        ":any",
+        ":assert",
+        ":config",
+        ":detail",
+        ":exception",
+        ":function",
+        ":function_types",
+        ":mpl",
+        ":noncopyable",
+        ":optional",
+        ":preprocessor",
+        ":shared_ptr",
+        ":smart_ptr",
+        ":static_assert",
+        ":thread",
+        ":typeof",
+        ":type_traits",
+        ":utility",
+    ],
+)


### PR DESCRIPTION
Issues
========
- undefined reference to `boost::system::detail::generic_category_instance`

Workarounds
========
- add `-DBOOST_ERROR_CODE_HEADER_ONLY` to `copts`
