### PR TITLE
Upgrade to boost 1.71.0.

### DIFF
--- a/BUILD.boost
+++ b/BUILD.boost
@@ -330,10 +330,12 @@ boost_library(
         ":core",
         ":detail",
         ":endian",
+        ":mp11",
         ":smart_ptr",
         ":static_assert",
         ":system",
         ":throw_exception",
+        ":tribool",
         ":utility",
     ],
 )
@@ -603,6 +605,7 @@ boost_library(
         ":config",
         ":core",
         ":detail",
+        ":functional",
         ":integer",
         ":move",
         ":throw_exception",
@@ -745,7 +748,7 @@ boost_library(
         ":lexical_cast",
         ":math",
         ":mpl",
-        ":numeric",
+        ":numeric_conversion",
         ":qvm",
         ":range",
         ":rational",
@@ -800,8 +803,6 @@ boost_library(
     hdrs = [
         "boost/cstdint.hpp",
         "boost/integer_traits.hpp",
-        "boost/pending/integer_log2.hpp",
-        "boost/pending/lowest_bit.hpp",
     ],
     deps = [
         ":static_assert",
@@ -898,6 +899,7 @@ boost_library(
         "@net_zlib_zlib//:zlib",
         "@org_bzip_bzip2//:bz2lib",
         "@org_lzma_lzma//:lzma",
+        "@com_github_facebook_zstd//:zstd",
     ],
 )
 
@@ -1132,7 +1134,7 @@ boost_library(
         ":iterator",
         ":mpl",
         ":noncopyable",
-        ":numeric",
+        ":numeric_interval",
         ":range",
         ":serialization",
         ":shared_array",
@@ -1148,13 +1150,22 @@ boost_library(
     name = "numeric_odeint",
     hdrs = glob([
         "boost/numeric/odeint/**/*.hpp",
-    ]),
+    ]) + [
+        "boost/numeric/odeint.hpp",
+    ],
     deps = [
         ":fusion",
         ":lexical_cast",
         ":math",
+        # There is currently a circular dependency between math and
+        # multiprecision. We know that :numeric_odeint triggers it,
+        # despite only depending directly on :math, so we include
+        # :multiprecision here. Some users of :math will need to do
+        # so as well.
+        # See: https://github.com/boostorg/math/issues/201
+        ":multiprecision",
         ":multi_array",
-        ":numeric",
+        ":numeric_ublas",
         ":serialization",
         ":units",
     ],
@@ -1189,6 +1200,9 @@ boost_library(
 
 boost_library(
     name = "parameter",
+    deps = [
+        ":mp11",
+    ],
 )
 
 boost_library(
@@ -1811,6 +1825,13 @@ boost_library(
 )
 
 boost_library(
+    name = "variant2",
+    deps = [
+        ":mp11",
+    ],
+)
+
+boost_library(
     name = "version",
 )
 
@@ -1833,7 +1854,14 @@ boost_library(
 )
 
 boost_library(
-    name = "numeric",
+    name = "numeric_interval",
+    hdrs = glob([
+        "boost/numeric/interval/**/*.hpp",
+    ]) + [
+        "boost/numeric/interval.hpp",
+    ],
+    deps = [
+    ],
 )
 
 boost_library(

--- a/BUILD.zstd
+++ b/BUILD.zstd
@@ -1,0 +1,223 @@
+cc_library(
+    name = 'zstd',
+    hdrs = ['lib/zstd.h'],
+    includes = ['lib'],
+    visibility = ['//visibility:public'],
+    deps = [
+        ':common',
+        ':compress',
+        ':decompress',
+        ':deprecated',
+    ],
+)
+
+cc_library(
+    name = 'compress',
+    visibility = ['//visibility:public'],
+    hdrs = glob([
+        'lib/compress/zstd*.h',
+    ]),
+    srcs = glob(['lib/compress/zstd*.c', 'lib/compress/hist.c']),
+    deps = [':common'],
+)
+
+cc_library(
+    name = 'decompress',
+    visibility = ['//visibility:public'],
+    hdrs = glob([
+        'lib/decompress/*_impl.h',
+    ]),
+    srcs = glob(['lib/decompress/zstd*.c']) + [
+        'lib/decompress/zstd_decompress_internal.h',
+        'lib/decompress/zstd_decompress_block.h',
+        'lib/decompress/zstd_ddict.h',
+    ],
+    deps = [
+        ':common',
+        ':legacy',
+    ],
+)
+
+cc_library(
+    name = 'deprecated',
+    visibility = ['//visibility:public'],
+    hdrs = glob([
+        'lib/deprecated/*.h',
+    ]),
+    srcs = glob(['lib/deprecated/*.c']),
+    deps = [':common'],
+)
+
+cc_library(
+    name = 'legacy',
+    visibility = ['//visibility:public'],
+    includes = [ 'lib/legacy' ],
+    hdrs = glob([
+        'lib/legacy/*.h',
+    ]),
+    srcs = glob(['lib/legacy/*.c']),
+    deps = [':common'],
+    defines = [
+        'ZSTD_LEGACY_SUPPORT=4',
+    ],
+)
+
+cc_library(
+    name = 'compiler',
+    visibility = ['//visibility:public'],
+    includes = ['lib/common'],
+    hdrs = [
+        'lib/common/compiler.h',
+    ],
+)
+
+cc_library(
+    name = 'cpu',
+    visibility = ['//visibility:public'],
+    hdrs = [
+        'lib/common/cpu.h',
+    ],
+)
+
+cc_library(
+    name = 'bitstream',
+    visibility = ['//visibility:public'],
+    hdrs = [
+        'lib/common/bitstream.h',
+    ],
+)
+
+cc_library(
+    name = 'entropy',
+    visibility = ['//visibility:public'],
+    hdrs = [
+        'lib/common/fse.h',
+        'lib/common/huf.h',
+    ],
+    srcs = [
+        'lib/common/entropy_common.c',
+        'lib/common/fse_decompress.c',
+        'lib/compress/fse_compress.c',
+        'lib/compress/huf_compress.c',
+        'lib/compress/hist.h',
+        'lib/decompress/huf_decompress.c',
+    ],
+    deps = [
+        ':debug',
+        ':bitstream',
+        ':compiler',
+        ':errors',
+        ':mem',
+    ],
+)
+
+cc_library(
+    name = 'errors',
+    visibility = ['//visibility:public'],
+    hdrs = [
+        'lib/common/error_private.h',
+        'lib/common/zstd_errors.h',
+    ],
+    srcs = ['lib/common/error_private.c'],
+)
+
+cc_library(
+    name = 'mem',
+    visibility = ['//visibility:public'],
+    hdrs = [
+        'lib/common/mem.h',
+    ],
+)
+
+cc_library(
+    name = 'pool',
+    visibility = ['//visibility:public'],
+    hdrs = [
+        'lib/common/pool.h',
+    ],
+    srcs = [
+        'lib/common/pool.c'
+    ],
+    deps = [
+        ':threading',
+        ':zstd_common',
+    ],
+)
+
+cc_library(
+    name = 'threading',
+    visibility = ['//visibility:public'],
+    hdrs = [
+        'lib/common/threading.h',
+    ],
+    srcs = ['lib/common/threading.c'],
+    defines = [
+        'ZSTD_MULTITHREAD',
+    ],
+    linkopts = [
+        '-pthread',
+    ],
+    deps = [
+        ':debug',
+    ],
+)
+
+cc_library(
+    name = 'xxhash',
+    visibility = ['//visibility:public'],
+    hdrs = [
+        'lib/common/xxhash.h',
+    ],
+    srcs = ['lib/common/xxhash.c'],
+    defines = [
+        'XXH_NAMESPACE=ZSTD_',
+    ],
+)
+
+cc_library(
+    name = 'zstd_common',
+    visibility = ['//visibility:public'],
+    hdrs = [
+        'lib/zstd.h',
+        'lib/common/zstd_internal.h',
+    ],
+    includes = ['lib'],
+    srcs = ['lib/common/zstd_common.c'],
+    deps = [
+        ':compiler',
+        ':errors',
+        ':mem',
+        ':debug',
+        ':entropy',
+        ':xxhash',
+    ],
+)
+
+cc_library(
+    name = 'debug',
+    visibility = ["//visibility:public"],
+    includes = ['lib/common'],
+    hdrs = [
+        'lib/common/debug.h',
+    ],
+    srcs = [
+        'lib/common/debug.c',
+    ],
+)
+
+cc_library(
+    name = 'common',
+    deps = [
+        ':debug',
+        ':bitstream',
+        ':compiler',
+        ':cpu',
+        ':entropy',
+        ':errors',
+        ':mem',
+        ':pool',
+        ':threading',
+        ':xxhash',
+        ':zstd_common',
+    ]
+)

--- a/boost/boost.bzl
+++ b/boost/boost.bzl
@@ -136,14 +136,25 @@ def boost_deps():
             ],
         )
 
+    if "com_github_facebook_zstd" not in native.existing_rules():
+        http_archive(
+            name = "com_github_facebook_zstd",
+            urls = [
+                "https://github.com/facebook/zstd/releases/download/v1.4.4/zstd-1.4.4.tar.gz",
+            ],
+            sha256 = "59ef70ebb757ffe74a7b3fe9c305e2ba3350021a918d168a046c6300aeea9315",
+            build_file = "@com_github_nelhage_rules_boost//:BUILD.zstd",
+            strip_prefix = "zstd-1.4.4",
+        )
+
     if "boost" not in native.existing_rules():
         http_archive(
             name = "boost",
             build_file = "@com_github_nelhage_rules_boost//:BUILD.boost",
-            sha256 = "da3411ea45622579d419bfda66f45cd0f8c32a181d84adfa936f5688388995cf",
-            strip_prefix = "boost_1_68_0",
+            sha256 = "d73a8da01e8bf8c7eda40b4c84915071a8c8a0df4a6734537ddde4a8580524ee",
+            strip_prefix = "boost_1_71_0",
             urls = [
-                "https://%s.dl.sourceforge.net/project/boost/boost/1.68.0/boost_1_68_0.tar.gz" % m
-                for m in SOURCEFORGE_MIRRORS
+                "https://dl.bintray.com/boostorg/release/1.71.0/source/boost_1_71_0.tar.bz2",
             ],
+            patch_cmds = [ "rm -f doc/pdf/BUILD", ],
         )

--- a/test/BUILD
+++ b/test/BUILD
@@ -449,3 +449,13 @@ cc_test(
         "@boost//:hana",
     ],
 )
+
+cc_test(
+    name = "variant2_test",
+    size = "small",
+    srcs = ["variant2_test.cc"],
+    copts = ["-std=c++14"],
+    deps = [
+        "@boost//:variant2",
+    ],
+)

--- a/test/WORKSPACE
+++ b/test/WORKSPACE
@@ -13,7 +13,7 @@ load("@com_github_nelhage_rules_boost//:boost/boost.bzl", "boost_deps")
 # new_local_repository(
 #     name = "boost",
 #     build_file = "@com_github_nelhage_rules_boost//:BUILD.boost",
-#     path = "/home/nelhage/code/boost_1_66_0/",
+#     path = "/home/nelhage/code/boost_1_71_0/",
 # )
 
 boost_deps()

--- a/test/iostreams_test.cc
+++ b/test/iostreams_test.cc
@@ -1,24 +1,54 @@
 #include <boost/iostreams/device/back_inserter.hpp>
 #include <boost/iostreams/filter/gzip.hpp>
+#include <boost/iostreams/filter/zstd.hpp>
 #include <boost/iostreams/filtering_stream.hpp>
 
 int main()
 {
-  std::string uncompressed ("hello");
-  std::string compressed;
-  std::string expected ("\x1f\x8b\x08\x00\x00\x00\x00\x00\x04\xff\xcb\x48\xcd\xc9\xc9\x07\x00\x86\xa6\x10\x36\x05\x00\x00\x00", 25);
+  {
+    std::string uncompressed ("hello");
+    std::string compressed;
+    std::string expected ("\x1f\x8b\x08\x00\x00\x00\x00\x00\x04\xff\xcb\x48\xcd\xc9\xc9\x07\x00\x86\xa6\x10\x36\x05\x00\x00\x00", 25);
 
-  boost::iostreams::filtering_ostream out;
-  out.push(
-      boost::iostreams::gzip_compressor(boost::iostreams::zlib::best_speed));
-  out.push(boost::iostreams::back_inserter(compressed));
-  boost::iostreams::write(out,
-                          reinterpret_cast<const char*>(uncompressed.data()),
-                          uncompressed.size());
-  boost::iostreams::close(out);
+    boost::iostreams::filtering_ostream out;
+    out.push(
+        boost::iostreams::gzip_compressor(boost::iostreams::zlib::best_speed));
+    out.push(boost::iostreams::back_inserter(compressed));
+    boost::iostreams::write(out,
+                            reinterpret_cast<const char*>(uncompressed.data()),
+                            uncompressed.size());
+    boost::iostreams::close(out);
 
-  if (compressed != expected) {
-    return 1;
+    if (compressed != expected) {
+      return 1;
+    }
+  }
+  {
+    std::string original ("hello");
+    std::string compressed;
+    std::string uncompressed;
+
+    boost::iostreams::filtering_ostream compressed_out;
+    compressed_out.push(
+        boost::iostreams::zstd_compressor(boost::iostreams::zstd::best_speed));
+    compressed_out.push(boost::iostreams::back_inserter(compressed));
+    boost::iostreams::write(compressed_out,
+                            reinterpret_cast<const char*>(original.data()),
+                            original.size());
+    boost::iostreams::close(compressed_out);
+
+    boost::iostreams::filtering_ostream uncompressed_out;
+    uncompressed_out.push(
+        boost::iostreams::zstd_decompressor());
+    uncompressed_out.push(boost::iostreams::back_inserter(uncompressed));
+    boost::iostreams::write(uncompressed_out,
+                            reinterpret_cast<const char*>(compressed.data()),
+                            compressed.size());
+    boost::iostreams::close(uncompressed_out);
+
+    if (uncompressed != original) {
+      return 1;
+    }
   }
 
   return 0;

--- a/test/variant2_test.cc
+++ b/test/variant2_test.cc
@@ -1,0 +1,6 @@
+#include <boost/variant2/variant.hpp>
+
+int main()
+{
+    return 0;
+}


### PR DESCRIPTION
- Adds zstd support to iostreams.
- Adds variant2 library.
- Gets rid of @boost//:numeric in favor of @boost//:numeric_interval.