### PR TITLE
Add support for Boost.Python.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ jobs:
           keys:
             - bazel-cache
 
-      - run: apt-get update && apt-get -y install pkg-config zip g++ zlib1g-dev unzip python curl ocl-icd-opencl-dev opencl-headers
+      - run: apt-get update && apt-get -y install pkg-config zip g++ zlib1g-dev unzip python curl ocl-icd-opencl-dev opencl-headers python-dev python-numpy
       - run: cd /tmp/ && curl -LO https://github.com/bazelbuild/bazel/releases/download/1.1.0/bazel-1.1.0-installer-linux-x86_64.sh
       - run: bash /tmp/bazel-1.1.0-installer-linux-x86_64.sh
       - run: cd test && cp .bazelrc.circle .bazelrc

--- a/BUILD.boost
+++ b/BUILD.boost
@@ -1276,6 +1276,47 @@ boost_library(
 )
 
 boost_library(
+    name = "python",
+    srcs = glob([
+        "libs/python/src/converter/*.cpp",
+        "libs/python/src/numpy/*.cpp",
+        "libs/python/src/object/*.cpp",
+    ]),
+    deps = [
+        ":bind",
+        ":call_traits",
+        ":config",
+        ":conversion",
+        ":detail",
+        ":foreach",
+        ":function",
+        ":graph",
+        ":get_pointer",
+        ":implicit_cast",
+        ":iterator",
+        ":lexical_cast",
+        ":limits",
+        ":mpl",
+        ":numeric_interval",
+        ":operators",
+        ":preprocessor",
+        ":ref",
+        ":scoped_ptr",
+        ":shared_ptr",
+        ":static_assert",
+        ":tuple",
+        ":type",
+        ":type_traits",
+        ":utility",
+        "@local_config_python//:python_headers",
+        "@local_config_python//:numpy_headers",
+    ] + select({
+        ":windows": ["@local_config_python//:python_lib"],
+        "//conditions:default": [],
+    }),
+)
+
+boost_library(
     name = "qvm",
     deps = [
         ":assert",

--- a/BUILD.boost
+++ b/BUILD.boost
@@ -1314,6 +1314,9 @@ boost_library(
         ":windows": ["@local_config_python//:python_lib"],
         "//conditions:default": [],
     }),
+    local_defines = [
+        "BOOST_PYTHON_SOURCE",
+    ],
 )
 
 boost_library(

--- a/boost/boost.bzl
+++ b/boost/boost.bzl
@@ -45,6 +45,7 @@ def hdr_list(library_name):
 def boost_library(
         name,
         defines = None,
+        local_defines = None,
         includes = None,
         hdrs = None,
         srcs = None,
@@ -55,6 +56,9 @@ def boost_library(
         visibility = ["//visibility:public"]):
     if defines == None:
         defines = []
+
+    if local_defines == None:
+        local_defines = []
 
     if includes == None:
         includes = []
@@ -78,6 +82,7 @@ def boost_library(
         name = name,
         visibility = visibility,
         defines = default_defines + defines,
+        local_defines = local_defines,
         includes = includes_list(name) + includes,
         hdrs = hdr_list(name) + hdrs,
         srcs = srcs_list(name, exclude_src) + srcs,

--- a/py/BUILD.tpl
+++ b/py/BUILD.tpl
@@ -1,0 +1,69 @@
+licenses(["restricted"])
+
+package(default_visibility = ["//visibility:public"])
+
+# Point both runtimes to the same python binary to ensure we always
+# use the python binary specified by ./configure.py script.
+load("@bazel_tools//tools/python:toolchain.bzl", "py_runtime_pair")
+
+py_runtime(
+    name = "py2_runtime",
+    interpreter_path = "%{PYTHON_BIN_PATH}",
+    python_version = "PY2",
+)
+
+py_runtime(
+    name = "py3_runtime",
+    interpreter_path = "%{PYTHON_BIN_PATH}",
+    python_version = "PY3",
+)
+
+py_runtime_pair(
+    name = "py_runtime_pair",
+    py2_runtime = ":py2_runtime",
+    py3_runtime = ":py3_runtime",
+)
+
+toolchain(
+    name = "py_toolchain",
+    toolchain = ":py_runtime_pair",
+    toolchain_type = "@bazel_tools//tools/python:toolchain_type",
+)
+
+# To build Python C/C++ extension on Windows, we need to link to python import library pythonXY.lib
+# See https://docs.python.org/3/extending/windows.html
+cc_import(
+    name = "python_lib",
+    interface_library = select({
+        ":windows": ":python_import_lib",
+        # A placeholder for Unix platforms which makes --no_build happy.
+        "//conditions:default": "not-existing.lib",
+    }),
+    system_provided = 1,
+)
+
+cc_library(
+    name = "python_headers",
+    hdrs = [":python_include"],
+    deps = select({
+        ":windows": [":python_lib"],
+        "//conditions:default": [],
+    }),
+    includes = ["python_include"],
+)
+
+cc_library(
+    name = "numpy_headers",
+    hdrs = [":numpy_include"],
+    includes = ["numpy_include"],
+)
+
+config_setting(
+    name = "windows",
+    values = {"cpu": "x64_windows"},
+    visibility = ["//visibility:public"],
+)
+
+%{PYTHON_INCLUDE_GENRULE}
+%{NUMPY_INCLUDE_GENRULE}
+%{PYTHON_IMPORT_LIB_GENRULE}

--- a/py/README.md
+++ b/py/README.md
@@ -1,0 +1,30 @@
+== Overview
+
+A simple workspace rule to configure an external repository that contains
+targets for the host's installation of python and numpy headers. The
+implementation is currently quite naive and does not integrate at all with
+Bazel's python toolchain support.
+
+Your mileage may vary.
+
+This implementation comes from TensorFlow:
+https://github.com/tensorflow/tensorflow/tree/master/third_party/py.
+
+== Usage
+
+If you want to use Boost.Python (`@boost//:python`), you need to declare an
+external repository `@local_config_python` that declares the `cc_library`s
+`:python_headers` and `:numpy_headers`. On windows, it also needs to declare a
+`cc_library` of `:python_lib`. This repository rule will attempt to declare
+such a repository for you, using the `python` binary it finds on your `PATH`.
+
+In your `WORKSPACE`, add:
+
+```
+load("@com_github_nelhage_rules_boost//py:python_configure.bzl", "python_configure")
+
+python_configure(name = "local_config_python")
+```
+
+The detection can use a different `python` binary by setting `PYTHON_BIN_PATH`
+in your environment.

--- a/py/python_configure.bzl
+++ b/py/python_configure.bzl
@@ -1,0 +1,303 @@
+"""Repository rule for Python autoconfiguration.
+`python_configure` depends on the following environment variables:
+  * `PYTHON_BIN_PATH`: location of python binary.
+  * `PYTHON_LIB_PATH`: Location of python libraries.
+"""
+
+_BAZEL_SH = "BAZEL_SH"
+_PYTHON_BIN_PATH = "PYTHON_BIN_PATH"
+
+def _tpl(repository_ctx, tpl, substitutions = {}, out = None):
+    if not out:
+        out = tpl
+    repository_ctx.template(
+        out,
+        Label("//:py/%s.tpl" % tpl),
+        substitutions,
+    )
+
+def _fail(msg):
+    """Output failure message when auto configuration fails."""
+    red = "\033[0;31m"
+    no_color = "\033[0m"
+    fail("%sPython Configuration Error:%s %s\n" % (red, no_color, msg))
+
+def _is_windows(repository_ctx):
+    """Returns true if the host operating system is windows."""
+    os_name = repository_ctx.os.name.lower()
+    if os_name.find("windows") != -1:
+        return True
+    return False
+
+def _execute(
+        repository_ctx,
+        cmdline,
+        error_msg = None,
+        error_details = None,
+        empty_stdout_fine = False):
+    """Executes an arbitrary shell command.
+    Args:
+      repository_ctx: the repository_ctx object
+      cmdline: list of strings, the command to execute
+      error_msg: string, a summary of the error if the command fails
+      error_details: string, details about the error or steps to fix it
+      empty_stdout_fine: bool, if True, an empty stdout result is fine, otherwise
+        it's an error
+    Return:
+      the result of repository_ctx.execute(cmdline)
+    """
+    result = repository_ctx.execute(cmdline)
+    if result.stderr or not (empty_stdout_fine or result.stdout):
+        _fail("\n".join([
+            error_msg.strip() if error_msg else "Repository command failed",
+            result.stderr.strip(),
+            error_details if error_details else "",
+        ]))
+    return result
+
+def _read_dir(repository_ctx, src_dir):
+    """Returns a string with all files in a directory.
+    Finds all files inside a directory, traversing subfolders and following
+    symlinks. The returned string contains the full path of all files
+    separated by line breaks.
+    """
+    if _is_windows(repository_ctx):
+        src_dir = src_dir.replace("/", "\\")
+        find_result = _execute(
+            repository_ctx,
+            ["cmd.exe", "/c", "dir", src_dir, "/b", "/s", "/a-d"],
+            empty_stdout_fine = True,
+        )
+
+        # src_files will be used in genrule.outs where the paths must
+        # use forward slashes.
+        result = find_result.stdout.replace("\\", "/")
+    else:
+        find_result = _execute(
+            repository_ctx,
+            ["find", src_dir, "-follow", "-type", "f"],
+            empty_stdout_fine = True,
+        )
+        result = find_result.stdout
+    return result
+
+def _genrule(src_dir, genrule_name, command, outs):
+    """Returns a string with a genrule.
+    Genrule executes the given command and produces the given outputs.
+    """
+    return (
+        "genrule(\n" +
+        '    name = "' +
+        genrule_name + '",\n' +
+        "    outs = [\n" +
+        outs +
+        "\n    ],\n" +
+        '    cmd = """\n' +
+        command +
+        '\n   """,\n' +
+        ")\n"
+    )
+
+def _norm_path(path):
+    """Returns a path with '/' and remove the trailing slash."""
+    path = path.replace("\\", "/")
+    if path[-1] == "/":
+        path = path[:-1]
+    return path
+
+def _symlink_genrule_for_dir(
+        repository_ctx,
+        src_dir,
+        dest_dir,
+        genrule_name,
+        src_files = [],
+        dest_files = []):
+    """Returns a genrule to symlink(or copy if on Windows) a set of files.
+    If src_dir is passed, files will be read from the given directory; otherwise
+    we assume files are in src_files and dest_files
+    """
+    if src_dir != None:
+        src_dir = _norm_path(src_dir)
+        dest_dir = _norm_path(dest_dir)
+        files = "\n".join(sorted(_read_dir(repository_ctx, src_dir).splitlines()))
+
+        # Create a list with the src_dir stripped to use for outputs.
+        dest_files = files.replace(src_dir, "").splitlines()
+        src_files = files.splitlines()
+    command = []
+    outs = []
+    for i in range(len(dest_files)):
+        if dest_files[i] != "":
+            # If we have only one file to link we do not want to use the dest_dir, as
+            # $(@D) will include the full path to the file.
+            dest = "$(@D)/" + dest_dir + dest_files[i] if len(dest_files) != 1 else "$(@D)/" + dest_files[i]
+
+            # Copy the headers to create a sandboxable setup.
+            cmd = "cp -f"
+            command.append(cmd + ' "%s" "%s"' % (src_files[i], dest))
+            outs.append('        "' + dest_dir + dest_files[i] + '",')
+    genrule = _genrule(
+        src_dir,
+        genrule_name,
+        " && ".join(command),
+        "\n".join(outs),
+    )
+    return genrule
+
+def _get_python_bin(repository_ctx):
+    """Gets the python bin path."""
+    python_bin = repository_ctx.os.environ.get(_PYTHON_BIN_PATH)
+    if python_bin != None:
+        return python_bin
+    python_bin_path = repository_ctx.which("python")
+    if python_bin_path != None:
+        return str(python_bin_path)
+    _fail("Cannot find python in PATH, please make sure " +
+          "python is installed and add its directory in PATH, or --define " +
+          "%s='/something/else'.\nPATH=%s" % (
+              _PYTHON_BIN_PATH,
+              repository_ctx.os.environ.get("PATH", ""),
+          ))
+
+def _get_bash_bin(repository_ctx):
+    """Gets the bash bin path."""
+    bash_bin = repository_ctx.os.environ.get(_BAZEL_SH)
+    if bash_bin != None:
+        return bash_bin
+    else:
+        bash_bin_path = repository_ctx.which("bash")
+        if bash_bin_path != None:
+            return str(bash_bin_path)
+        else:
+            _fail("Cannot find bash in PATH, please make sure " +
+                  "bash is installed and add its directory in PATH, or --define " +
+                  "%s='/path/to/bash'.\nPATH=%s" % (
+                      _BAZEL_SH,
+                      repository_ctx.os.environ.get("PATH", ""),
+                  ))
+
+def _check_python_bin(repository_ctx, python_bin):
+    """Checks the python bin path."""
+    cmd = '[[ -x "%s" ]] && [[ ! -d "%s" ]]' % (python_bin, python_bin)
+    result = repository_ctx.execute([_get_bash_bin(repository_ctx), "-c", cmd])
+    if result.return_code == 1:
+        _fail("--define %s='%s' is not executable. Is it the python binary?" % (
+            _PYTHON_BIN_PATH,
+            python_bin,
+        ))
+
+def _get_python_include(repository_ctx, python_bin):
+    """Gets the python include path."""
+    result = _execute(
+        repository_ctx,
+        [
+            python_bin,
+            "-c",
+            "from __future__ import print_function;" +
+            "from distutils import sysconfig;" +
+            "print(sysconfig.get_python_inc())",
+        ],
+        error_msg = "Problem getting python include path.",
+        error_details = ("Is the Python binary path set up right? " +
+                         "(See " + _PYTHON_BIN_PATH + ".) " +
+                         "Is distutils installed?"),
+    )
+    return result.stdout.splitlines()[0]
+
+def _get_windows_python_import_lib_name(repository_ctx, python_bin):
+    """Get Python import library name (pythonXY.lib) on Windows."""
+    result = _execute(
+        repository_ctx,
+        [
+            python_bin,
+            "-c",
+            "import sys;" +
+            'print("python" + str(sys.version_info[0]) + ' +
+            '      str(sys.version_info[1]) + ".lib")',
+        ],
+        error_msg = "Problem getting python import library.",
+        error_details = ("Is the Python binary path set up right? " +
+                         "(See " + _PYTHON_BIN_PATH + ".) "),
+    )
+    return result.stdout.splitlines()[0]
+
+def _get_numpy_include(repository_ctx, python_bin):
+    """Gets the numpy include path."""
+    return _execute(
+        repository_ctx,
+        [
+            python_bin,
+            "-c",
+            "from __future__ import print_function;" +
+            "import numpy;" +
+            " print(numpy.get_include());",
+        ],
+        error_msg = "Problem getting numpy include path.",
+        error_details = "Is numpy installed?",
+    ).stdout.splitlines()[0]
+
+def _create_local_python_repository(repository_ctx):
+    """Creates the repository containing files set up to build with Python."""
+    python_bin = _get_python_bin(repository_ctx)
+    _check_python_bin(repository_ctx, python_bin)
+    python_include = _get_python_include(repository_ctx, python_bin)
+    numpy_include = _get_numpy_include(repository_ctx, python_bin) + "/numpy"
+    python_include_rule = _symlink_genrule_for_dir(
+        repository_ctx,
+        python_include,
+        "python_include",
+        "python_include",
+    )
+    python_import_lib_genrule = ""
+
+    # To build Python C/C++ extension on Windows, we need to link to python import library pythonXY.lib
+    # See https://docs.python.org/3/extending/windows.html
+    if _is_windows(repository_ctx):
+        python_include = _norm_path(python_include)
+        python_import_lib_name = _get_windows_python_import_lib_name(repository_ctx, python_bin)
+        python_import_lib_src = python_include.rsplit("/", 1)[0] + "/libs/" + python_import_lib_name
+        python_import_lib_genrule = _symlink_genrule_for_dir(
+            repository_ctx,
+            None,
+            "",
+            "python_import_lib",
+            [python_import_lib_src],
+            [python_import_lib_name],
+        )
+    numpy_include_rule = _symlink_genrule_for_dir(
+        repository_ctx,
+        numpy_include,
+        "numpy_include/numpy",
+        "numpy_include",
+    )
+    _tpl(repository_ctx, "BUILD", {
+        "%{PYTHON_BIN_PATH}": python_bin,
+        "%{PYTHON_INCLUDE_GENRULE}": python_include_rule,
+        "%{PYTHON_IMPORT_LIB_GENRULE}": python_import_lib_genrule,
+        "%{NUMPY_INCLUDE_GENRULE}": numpy_include_rule,
+    })
+
+def _create_remote_python_repository(repository_ctx, remote_config_repo):
+    """Creates pointers to a remotely configured repo set up to build with Python.
+    """
+    repository_ctx.template("BUILD", Label(remote_config_repo + ":BUILD"), {})
+
+def _python_autoconf_impl(repository_ctx):
+    """Implementation of the python_autoconf repository rule."""
+    _create_local_python_repository(repository_ctx)
+
+python_configure = repository_rule(
+    implementation = _python_autoconf_impl,
+    environ = [
+        _BAZEL_SH,
+        _PYTHON_BIN_PATH,
+    ],
+)
+"""Detects and configures the local Python.
+Add the following to your WORKSPACE FILE:
+```python
+python_configure(name = "local_config_python")
+```
+Args:
+  name: A unique name for this workspace rule.
+"""

--- a/test/BUILD
+++ b/test/BUILD
@@ -1,3 +1,11 @@
+config_setting(
+    name = "windows",
+    constraint_values = [
+        "@bazel_tools//platforms:windows",
+    ],
+    visibility = ["//visibility:public"],
+)
+
 cc_test(
     name = "accumulators_test",
     size = "small",
@@ -297,14 +305,22 @@ cc_binary(
     ],
 )
 
+genrule(
+    name = "gen_python_mod.pyd",
+    srcs = [":python_mod.so"],
+    outs = ["python_mod.pyd"],
+    cmd = "cp $< $@",
+)
+
 py_test(
     name = "python_test",
     srcs = ["python_test.py"],
     main = "python_test.py",
     python_version = "PY2",
-    data = [
-        ":python_mod.so",
-    ]
+    data = select({
+        ":windows": [":python_mod.pyd"],
+        "//conditions:default": [":python_mod.so"],
+    }),
 )
 
 cc_test(

--- a/test/BUILD
+++ b/test/BUILD
@@ -288,6 +288,24 @@ cc_test(
     ],
 )
 
+cc_binary(
+    name = "python_mod.so",
+    srcs = ["python_mod.cc"],
+    linkshared = True,
+    deps = [
+        "@boost//:python",
+    ],
+)
+
+py_test(
+    name = "python_test",
+    srcs = ["python_test.py"],
+    main = "python_test.py",
+    data = [
+        ":python_mod.so",
+    ]
+)
+
 cc_test(
     name = "qvm_test",
     size = "small",

--- a/test/BUILD
+++ b/test/BUILD
@@ -301,6 +301,7 @@ py_test(
     name = "python_test",
     srcs = ["python_test.py"],
     main = "python_test.py",
+    python_version = "PY2",
     data = [
         ":python_mod.so",
     ]

--- a/test/WORKSPACE
+++ b/test/WORKSPACE
@@ -4,6 +4,9 @@ local_repository(
 )
 
 load("@com_github_nelhage_rules_boost//:boost/boost.bzl", "boost_deps")
+load("@com_github_nelhage_rules_boost//:py/python_configure.bzl", "python_configure")
+
+python_configure(name = "local_config_python")
 
 # boost_deps() will re-download the tarball every time BUILD.boost
 # changes, which is frustrating for doing development. Download it

--- a/test/python_mod.cc
+++ b/test/python_mod.cc
@@ -1,0 +1,12 @@
+char const* greet()
+{
+   return "hello, world";
+}
+
+#include <boost/python.hpp>
+
+BOOST_PYTHON_MODULE(python_mod)
+{
+    using namespace boost::python;
+    def("greet", greet);
+}

--- a/test/python_test.py
+++ b/test/python_test.py
@@ -1,0 +1,2 @@
+from python_mod import greet
+print(greet())


### PR DESCRIPTION
Boost.Python becomes available if you declare an external repository with an
appropriate structure for getting the Python and numpy dependencies. Also adds
a workspace rule to autodetect and create an external repository based on the
`python` binary on the `PATH`.