### PR TITLE
Add missing deps to utility

### DIFF
--- a/BUILD.boost
+++ b/BUILD.boost
@@ -1794,13 +1794,17 @@ boost_library(
     name = "utility",
     hdrs = [
         "boost/compressed_pair.hpp",
-        "boost/next_prior.hpp",
     ],
     deps = [
         ":config",
+        ":container_hash",
+        ":core",
+        ":cstdint",
         ":detail",
         ":preprocessor",
+        ":static_assert",
         ":swap",
+        ":throw_exception",
         ":type_traits",
     ],
 )


### PR DESCRIPTION
next_prior.hpp is removed as it is a part of :iterator.