### PR TITLE
Add serialization dep on accumulators

### DIFF
--- a/BUILD.boost
+++ b/BUILD.boost
@@ -234,6 +234,7 @@ boost_library(
         ":fusion",
         ":mpl",
         ":parameter",
+        ":serialization",
         ":type_traits",
         ":utility",
         ":version",


### PR DESCRIPTION
This is now required, an accumulators file includes a serialization file in boost 1.72.0