### PR TITLE
Removed deprecated-declarations warnings in @boost//:container on mac

### DIFF
--- a/BUILD.boost
+++ b/BUILD.boost
@@ -1,8 +1,9 @@
 load("@bazel_skylib//rules:copy_file.bzl", "copy_file")
+load("@bazel_skylib//lib:selects.bzl", "selects")
 load("@com_github_nelhage_rules_boost//:boost/boost.bzl", "boost_library", "boost_so_library", "hdr_list")
 
-_w_no_deprecated = select({
-    ":linux": [
+_w_no_deprecated = selects.with_or({
+    (":linux", ":osx"): [
         "-Wno-deprecated-declarations",
     ],
     "//conditions:default": [],
@@ -506,6 +507,7 @@ boost_library(
     hdrs = [
         "libs/container/src/dlmalloc_2_8_6.c",
     ],
+    copts = _w_no_deprecated,
     deps = [
         ":config",
         ":core",


### PR DESCRIPTION
On mac, boost kept producing a slew of warnings related to the container component, as shown below. This MR suppresses these warnings by adding `-Wno-deprecated-declarations` to `@boost//:container`.

Warnings pre-PR:
```
WARNING: From Compiling external/boost/libs/container/src/dlmalloc_ext_2_8_6.c:
In file included from external/boost/libs/container/src/dlmalloc_ext_2_8_6.c:36:
external/boost/libs/container/src/dlmalloc_2_8_6.c:4085:27: warning: 'sbrk' is deprecated [-Wdeprecated-declarations]
      char* base = (char*)CALL_MORECORE(0);
                          ^
external/boost/libs/container/src/dlmalloc_2_8_6.c:1714:37: note: expanded from macro 'CALL_MORECORE'
        #define CALL_MORECORE(S)    MORECORE_DEFAULT(S)
                                    ^
external/boost/libs/container/src/dlmalloc_2_8_6.c:666:26: note: expanded from macro 'MORECORE_DEFAULT'#define MORECORE_DEFAULT sbrk
                         ^
/Applications/Xcode-beta.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk/usr/include/unistd.h:582:1: note: 'sbrk' has been explicitly marked deprecated here
__deprecated __WATCHOS_PROHIBITED __TVOS_PROHIBITED
^
/Applications/Xcode-beta.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk/usr/include/sys/cdefs.h:187:40: note: expanded from macro '__deprecated'
#define __deprecated    __attribute__((__deprecated__))
                                       ^
In file included from external/boost/libs/container/src/dlmalloc_ext_2_8_6.c:36:
external/boost/libs/container/src/dlmalloc_2_8_6.c:4095:27: warning: 'sbrk' is deprecated [-Wdeprecated-declarations]
            (br = (char*)(CALL_MORECORE(ssize))) == base) {
                          ^
external/boost/libs/container/src/dlmalloc_2_8_6.c:1714:37: note: expanded from macro 'CALL_MORECORE'
        #define CALL_MORECORE(S)    MORECORE_DEFAULT(S)
                                    ^
external/boost/libs/container/src/dlmalloc_2_8_6.c:666:26: note: expanded from macro 'MORECORE_DEFAULT'
#define MORECORE_DEFAULT sbrk
                         ^
/Applications/Xcode-beta.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk/usr/include/unistd.h:582:1: note: 'sbrk' has been explicitly marked deprecated here
__deprecated __WATCHOS_PROHIBITED __TVOS_PROHIBITED
^
/Applications/Xcode-beta.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk/usr/include/sys/cdefs.h:187:40: note: expanded from macro '__deprecated'
#define __deprecated    __attribute__((__deprecated__))
                                       ^
In file included from external/boost/libs/container/src/dlmalloc_ext_2_8_6.c:36:
external/boost/libs/container/src/dlmalloc_2_8_6.c:4106:25: warning: 'sbrk' is deprecated [-Wdeprecated-declarations]
          (br = (char*)(CALL_MORECORE(ssize))) == ss->base+ss->size) {
                        ^
external/boost/libs/container/src/dlmalloc_2_8_6.c:1714:37: note: expanded from macro 'CALL_MORECORE'
        #define CALL_MORECORE(S)    MORECORE_DEFAULT(S)
                                    ^
external/boost/libs/container/src/dlmalloc_2_8_6.c:666:26: note: expanded from macro 'MORECORE_DEFAULT'
#define MORECORE_DEFAULT sbrk
                         ^
/Applications/Xcode-beta.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk/usr/include/unistd.h:582:1: note: 'sbrk' has been explicitly marked deprecated here
__deprecated __WATCHOS_PROHIBITED __TVOS_PROHIBITED
^
/Applications/Xcode-beta.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk/usr/include/sys/cdefs.h:187:40: note: expanded from macro '__deprecated'
#define __deprecated    __attribute__((__deprecated__))
                                       ^
In file included from external/boost/libs/container/src/dlmalloc_ext_2_8_6.c:36:
external/boost/libs/container/src/dlmalloc_2_8_6.c:4118:32: warning: 'sbrk' is deprecated [-Wdeprecated-declarations]
            char* end = (char*)CALL_MORECORE(esize);
                               ^
external/boost/libs/container/src/dlmalloc_2_8_6.c:1714:37: note: expanded from macro 'CALL_MORECORE'
        #define CALL_MORECORE(S)    MORECORE_DEFAULT(S)
                                    ^
external/boost/libs/container/src/dlmalloc_2_8_6.c:666:26: note: expanded from macro 'MORECORE_DEFAULT'
#define MORECORE_DEFAULT sbrk
                         ^
/Applications/Xcode-beta.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk/usr/include/unistd.h:582:1: note: 'sbrk' has been explicitly marked deprecated here
__deprecated __WATCHOS_PROHIBITED __TVOS_PROHIBITED
^
/Applications/Xcode-beta.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk/usr/include/sys/cdefs.h:187:40: note: expanded from macro '__deprecated'
#define __deprecated    __attribute__((__deprecated__))
                                       ^
In file included from external/boost/libs/container/src/dlmalloc_ext_2_8_6.c:36:
external/boost/libs/container/src/dlmalloc_2_8_6.c:4122:22: warning: 'sbrk' is deprecated [-Wdeprecated-declarations]
              (void) CALL_MORECORE(-ssize);
                     ^
external/boost/libs/container/src/dlmalloc_2_8_6.c:1714:37: note: expanded from macro 'CALL_MORECORE'
        #define CALL_MORECORE(S)    MORECORE_DEFAULT(S)
                                    ^
external/boost/libs/container/src/dlmalloc_2_8_6.c:666:26: note: expanded from macro 'MORECORE_DEFAULT'
#define MORECORE_DEFAULT sbrk
                         ^
/Applications/Xcode-beta.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk/usr/include/unistd.h:582:1: note: 'sbrk' has been explicitly marked deprecated here
__deprecated __WATCHOS_PROHIBITED __TVOS_PROHIBITED
^
/Applications/Xcode-beta.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk/usr/include/sys/cdefs.h:187:40: note: expanded from macro '__deprecated'
#define __deprecated    __attribute__((__deprecated__))
                                       ^
In file included from external/boost/libs/container/src/dlmalloc_ext_2_8_6.c:36:
external/boost/libs/container/src/dlmalloc_2_8_6.c:4153:20: warning: 'sbrk' is deprecated [-Wdeprecated-declarations]
      br = (char*)(CALL_MORECORE(asize));
                   ^
external/boost/libs/container/src/dlmalloc_2_8_6.c:1714:37: note: expanded from macro 'CALL_MORECORE'
        #define CALL_MORECORE(S)    MORECORE_DEFAULT(S)
                                    ^
external/boost/libs/container/src/dlmalloc_2_8_6.c:666:26: note: expanded from macro 'MORECORE_DEFAULT'
#define MORECORE_DEFAULT sbrk
                         ^
/Applications/Xcode-beta.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk/usr/include/unistd.h:582:1: note: 'sbrk' has been explicitly marked deprecated here
__deprecated __WATCHOS_PROHIBITED __TVOS_PROHIBITED
^
/Applications/Xcode-beta.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk/usr/include/sys/cdefs.h:187:40: note: expanded from macro '__deprecated'
#define __deprecated    __attribute__((__deprecated__))
                                       ^
In file included from external/boost/libs/container/src/dlmalloc_ext_2_8_6.c:36:
external/boost/libs/container/src/dlmalloc_2_8_6.c:4154:21: warning: 'sbrk' is deprecated [-Wdeprecated-declarations]
      end = (char*)(CALL_MORECORE(0));
                    ^
external/boost/libs/container/src/dlmalloc_2_8_6.c:1714:37: note: expanded from macro 'CALL_MORECORE'
        #define CALL_MORECORE(S)    MORECORE_DEFAULT(S)
                                    ^
external/boost/libs/container/src/dlmalloc_2_8_6.c:666:26: note: expanded from macro 'MORECORE_DEFAULT'
#define MORECORE_DEFAULT sbrk
                         ^
/Applications/Xcode-beta.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk/usr/include/unistd.h:582:1: note: 'sbrk' has been explicitly marked deprecated here
__deprecated __WATCHOS_PROHIBITED __TVOS_PROHIBITED
^
/Applications/Xcode-beta.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk/usr/include/sys/cdefs.h:187:40: note: expanded from macro '__deprecated'
#define __deprecated    __attribute__((__deprecated__))
                                       ^
In file included from external/boost/libs/container/src/dlmalloc_ext_2_8_6.c:36:
external/boost/libs/container/src/dlmalloc_2_8_6.c:4323:36: warning: 'sbrk' is deprecated [-Wdeprecated-declarations]
            char* old_br = (char*)(CALL_MORECORE(0));
                                   ^
external/boost/libs/container/src/dlmalloc_2_8_6.c:1714:37: note: expanded from macro 'CALL_MORECORE'
        #define CALL_MORECORE(S)    MORECORE_DEFAULT(S)
                                    ^
external/boost/libs/container/src/dlmalloc_2_8_6.c:666:26: note: expanded from macro 'MORECORE_DEFAULT'
#define MORECORE_DEFAULT sbrk
                         ^
/Applications/Xcode-beta.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk/usr/include/unistd.h:582:1: note: 'sbrk' has been explicitly marked deprecated here
__deprecated __WATCHOS_PROHIBITED __TVOS_PROHIBITED
^
/Applications/Xcode-beta.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk/usr/include/sys/cdefs.h:187:40: note: expanded from macro '__deprecated'
#define __deprecated    __attribute__((__deprecated__))
                                       ^
In file included from external/boost/libs/container/src/dlmalloc_ext_2_8_6.c:36:
external/boost/libs/container/src/dlmalloc_2_8_6.c:4325:38: warning: 'sbrk' is deprecated [-Wdeprecated-declarations]
              char* rel_br = (char*)(CALL_MORECORE(-extra));
                                     ^
external/boost/libs/container/src/dlmalloc_2_8_6.c:1714:37: note: expanded from macro 'CALL_MORECORE'
        #define CALL_MORECORE(S)    MORECORE_DEFAULT(S)
                                    ^
external/boost/libs/container/src/dlmalloc_2_8_6.c:666:26: note: expanded from macro 'MORECORE_DEFAULT'
#define MORECORE_DEFAULT sbrk
                         ^
/Applications/Xcode-beta.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk/usr/include/unistd.h:582:1: note: 'sbrk' has been explicitly marked deprecated here
__deprecated __WATCHOS_PROHIBITED __TVOS_PROHIBITED
^
/Applications/Xcode-beta.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk/usr/include/sys/cdefs.h:187:40: note: expanded from macro '__deprecated'
#define __deprecated    __attribute__((__deprecated__))
                                       ^
In file included from external/boost/libs/container/src/dlmalloc_ext_2_8_6.c:36:
external/boost/libs/container/src/dlmalloc_2_8_6.c:4326:38: warning: 'sbrk' is deprecated [-Wdeprecated-declarations]
              char* new_br = (char*)(CALL_MORECORE(0));
                                     ^
external/boost/libs/container/src/dlmalloc_2_8_6.c:1714:37: note: expanded from macro 'CALL_MORECORE'
        #define CALL_MORECORE(S)    MORECORE_DEFAULT(S)
                                    ^
external/boost/libs/container/src/dlmalloc_2_8_6.c:666:26: note: expanded from macro 'MORECORE_DEFAULT'
#define MORECORE_DEFAULT sbrk
                         ^
/Applications/Xcode-beta.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk/usr/include/unistd.h:582:1: note: 'sbrk' has been explicitly marked deprecated here
__deprecated __WATCHOS_PROHIBITED __TVOS_PROHIBITED
^
/Applications/Xcode-beta.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk/usr/include/sys/cdefs.h:187:40: note: expanded from macro '__deprecated'
#define __deprecated    __attribute__((__deprecated__))
                                       ^
10 warnings generated.
```