### PR TITLE
Add boost outcome library to build rules

### DIFF
--- a/BUILD.boost
+++ b/BUILD.boost
@@ -1321,6 +1321,16 @@ boost_library(
 )
 
 boost_library(
+    name = "outcome",
+    deps = [
+        ":config",
+        ":exception",
+        ":smart_ptr",
+        ":system",
+    ],
+)
+
+boost_library(
     name = "parameter",
     deps = [
         ":mp11",


### PR DESCRIPTION
Fixes #172 by adding an "outcome" build target.