### PR TITLE
Suppress uninitialized variable warnings in zstd

### DIFF
--- a/BUILD.zstd
+++ b/BUILD.zstd
@@ -1,223 +1,226 @@
 cc_library(
-    name = 'zstd',
-    hdrs = ['lib/zstd.h'],
-    includes = ['lib'],
-    visibility = ['//visibility:public'],
+    name = "zstd",
+    hdrs = ["lib/zstd.h"],
+    includes = ["lib"],
+    visibility = ["//visibility:public"],
     deps = [
-        ':common',
-        ':compress',
-        ':decompress',
-        ':deprecated',
+        ":common",
+        ":compress",
+        ":decompress",
+        ":deprecated",
     ],
 )
 
 cc_library(
-    name = 'compress',
-    visibility = ['//visibility:public'],
-    hdrs = glob([
-        'lib/compress/zstd*.h',
+    name = "compress",
+    srcs = glob([
+        "lib/compress/zstd*.c",
+        "lib/compress/hist.c",
     ]),
-    srcs = glob(['lib/compress/zstd*.c', 'lib/compress/hist.c']),
-    deps = [':common'],
+    hdrs = glob([
+        "lib/compress/zstd*.h",
+    ]),
+    visibility = ["//visibility:public"],
+    deps = [":common"],
 )
 
 cc_library(
-    name = 'decompress',
-    visibility = ['//visibility:public'],
-    hdrs = glob([
-        'lib/decompress/*_impl.h',
-    ]),
-    srcs = glob(['lib/decompress/zstd*.c']) + [
-        'lib/decompress/zstd_decompress_internal.h',
-        'lib/decompress/zstd_decompress_block.h',
-        'lib/decompress/zstd_ddict.h',
+    name = "decompress",
+    srcs = glob(["lib/decompress/zstd*.c"]) + [
+        "lib/decompress/zstd_decompress_internal.h",
+        "lib/decompress/zstd_decompress_block.h",
+        "lib/decompress/zstd_ddict.h",
     ],
+    hdrs = glob([
+        "lib/decompress/*_impl.h",
+    ]),
+    visibility = ["//visibility:public"],
     deps = [
-        ':common',
-        ':legacy',
+        ":common",
+        ":legacy",
     ],
 )
 
 cc_library(
-    name = 'deprecated',
-    visibility = ['//visibility:public'],
+    name = "deprecated",
+    srcs = glob(["lib/deprecated/*.c"]),
     hdrs = glob([
-        'lib/deprecated/*.h',
+        "lib/deprecated/*.h",
     ]),
-    srcs = glob(['lib/deprecated/*.c']),
-    deps = [':common'],
+    visibility = ["//visibility:public"],
+    deps = [":common"],
 )
 
 cc_library(
-    name = 'legacy',
-    visibility = ['//visibility:public'],
-    includes = [ 'lib/legacy' ],
+    name = "legacy",
+    srcs = glob(["lib/legacy/*.c"]),
     hdrs = glob([
-        'lib/legacy/*.h',
+        "lib/legacy/*.h",
     ]),
-    srcs = glob(['lib/legacy/*.c']),
-    deps = [':common'],
     defines = [
-        'ZSTD_LEGACY_SUPPORT=4',
+        "ZSTD_LEGACY_SUPPORT=4",
     ],
+    includes = ["lib/legacy"],
+    visibility = ["//visibility:public"],
+    deps = [":common"],
 )
 
 cc_library(
-    name = 'compiler',
-    visibility = ['//visibility:public'],
-    includes = ['lib/common'],
+    name = "compiler",
     hdrs = [
-        'lib/common/compiler.h',
+        "lib/common/compiler.h",
     ],
+    includes = ["lib/common"],
+    visibility = ["//visibility:public"],
 )
 
 cc_library(
-    name = 'cpu',
-    visibility = ['//visibility:public'],
+    name = "cpu",
     hdrs = [
-        'lib/common/cpu.h',
+        "lib/common/cpu.h",
     ],
+    visibility = ["//visibility:public"],
 )
 
 cc_library(
-    name = 'bitstream',
-    visibility = ['//visibility:public'],
+    name = "bitstream",
     hdrs = [
-        'lib/common/bitstream.h',
+        "lib/common/bitstream.h",
     ],
+    visibility = ["//visibility:public"],
 )
 
 cc_library(
-    name = 'entropy',
-    visibility = ['//visibility:public'],
-    hdrs = [
-        'lib/common/fse.h',
-        'lib/common/huf.h',
-    ],
+    name = "entropy",
     srcs = [
-        'lib/common/entropy_common.c',
-        'lib/common/fse_decompress.c',
-        'lib/compress/fse_compress.c',
-        'lib/compress/huf_compress.c',
-        'lib/compress/hist.h',
-        'lib/decompress/huf_decompress.c',
+        "lib/common/entropy_common.c",
+        "lib/common/fse_decompress.c",
+        "lib/compress/fse_compress.c",
+        "lib/compress/hist.h",
+        "lib/compress/huf_compress.c",
+        "lib/decompress/huf_decompress.c",
     ],
+    hdrs = [
+        "lib/common/fse.h",
+        "lib/common/huf.h",
+    ],
+    visibility = ["//visibility:public"],
     deps = [
-        ':debug',
-        ':bitstream',
-        ':compiler',
-        ':errors',
-        ':mem',
+        ":bitstream",
+        ":compiler",
+        ":debug",
+        ":errors",
+        ":mem",
     ],
 )
 
 cc_library(
-    name = 'errors',
-    visibility = ['//visibility:public'],
+    name = "errors",
+    srcs = ["lib/common/error_private.c"],
     hdrs = [
-        'lib/common/error_private.h',
-        'lib/common/zstd_errors.h',
+        "lib/common/error_private.h",
+        "lib/common/zstd_errors.h",
     ],
-    srcs = ['lib/common/error_private.c'],
+    visibility = ["//visibility:public"],
 )
 
 cc_library(
-    name = 'mem',
-    visibility = ['//visibility:public'],
+    name = "mem",
     hdrs = [
-        'lib/common/mem.h',
+        "lib/common/mem.h",
     ],
+    visibility = ["//visibility:public"],
 )
 
 cc_library(
-    name = 'pool',
-    visibility = ['//visibility:public'],
-    hdrs = [
-        'lib/common/pool.h',
-    ],
+    name = "pool",
     srcs = [
-        'lib/common/pool.c'
+        "lib/common/pool.c",
     ],
+    hdrs = [
+        "lib/common/pool.h",
+    ],
+    visibility = ["//visibility:public"],
     deps = [
-        ':threading',
-        ':zstd_common',
+        ":threading",
+        ":zstd_common",
     ],
 )
 
 cc_library(
-    name = 'threading',
-    visibility = ['//visibility:public'],
+    name = "threading",
+    srcs = ["lib/common/threading.c"],
     hdrs = [
-        'lib/common/threading.h',
+        "lib/common/threading.h",
     ],
-    srcs = ['lib/common/threading.c'],
     defines = [
-        'ZSTD_MULTITHREAD',
+        "ZSTD_MULTITHREAD",
     ],
     linkopts = [
-        '-pthread',
+        "-pthread",
     ],
-    deps = [
-        ':debug',
-    ],
-)
-
-cc_library(
-    name = 'xxhash',
-    visibility = ['//visibility:public'],
-    hdrs = [
-        'lib/common/xxhash.h',
-    ],
-    srcs = ['lib/common/xxhash.c'],
-    defines = [
-        'XXH_NAMESPACE=ZSTD_',
-    ],
-)
-
-cc_library(
-    name = 'zstd_common',
-    visibility = ['//visibility:public'],
-    hdrs = [
-        'lib/zstd.h',
-        'lib/common/zstd_internal.h',
-    ],
-    includes = ['lib'],
-    srcs = ['lib/common/zstd_common.c'],
-    deps = [
-        ':compiler',
-        ':errors',
-        ':mem',
-        ':debug',
-        ':entropy',
-        ':xxhash',
-    ],
-)
-
-cc_library(
-    name = 'debug',
     visibility = ["//visibility:public"],
-    includes = ['lib/common'],
-    hdrs = [
-        'lib/common/debug.h',
-    ],
-    srcs = [
-        'lib/common/debug.c',
+    deps = [
+        ":debug",
     ],
 )
 
 cc_library(
-    name = 'common',
+    name = "xxhash",
+    srcs = ["lib/common/xxhash.c"],
+    hdrs = [
+        "lib/common/xxhash.h",
+    ],
+    defines = [
+        "XXH_NAMESPACE=ZSTD_",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "zstd_common",
+    srcs = ["lib/common/zstd_common.c"],
+    hdrs = [
+        "lib/common/zstd_internal.h",
+        "lib/zstd.h",
+    ],
+    includes = ["lib"],
+    visibility = ["//visibility:public"],
     deps = [
-        ':debug',
-        ':bitstream',
-        ':compiler',
-        ':cpu',
-        ':entropy',
-        ':errors',
-        ':mem',
-        ':pool',
-        ':threading',
-        ':xxhash',
-        ':zstd_common',
-    ]
+        ":compiler",
+        ":debug",
+        ":entropy",
+        ":errors",
+        ":mem",
+        ":xxhash",
+    ],
+)
+
+cc_library(
+    name = "debug",
+    srcs = [
+        "lib/common/debug.c",
+    ],
+    hdrs = [
+        "lib/common/debug.h",
+    ],
+    includes = ["lib/common"],
+    visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "common",
+    deps = [
+        ":bitstream",
+        ":compiler",
+        ":cpu",
+        ":debug",
+        ":entropy",
+        ":errors",
+        ":mem",
+        ":pool",
+        ":threading",
+        ":xxhash",
+        ":zstd_common",
+    ],
 )

--- a/BUILD.zstd
+++ b/BUILD.zstd
@@ -57,6 +57,7 @@ cc_library(
     hdrs = glob([
         "lib/legacy/*.h",
     ]),
+    copts = ["-Wno-uninitialized"],
     defines = [
         "ZSTD_LEGACY_SUPPORT=4",
     ],

--- a/BUILD.zstd
+++ b/BUILD.zstd
@@ -57,7 +57,11 @@ cc_library(
     hdrs = glob([
         "lib/legacy/*.h",
     ]),
-    copts = ["-Wno-uninitialized"],
+    copts =
+        select({
+            ":windows": [],
+            "//conditions:default": ["-Wno-uninitialized"],
+        }),
     defines = [
         "ZSTD_LEGACY_SUPPORT=4",
     ],
@@ -223,5 +227,12 @@ cc_library(
         ":threading",
         ":xxhash",
         ":zstd_common",
+    ],
+)
+
+config_setting(
+    name = "windows",
+    constraint_values = [
+        "@bazel_tools//platforms:windows",
     ],
 )


### PR DESCRIPTION
fix #176 