### PR TITLE
Broadened warning suppression to all unused

### DIFF
--- a/BUILD.boost
+++ b/BUILD.boost
@@ -9,13 +9,6 @@ _w_no_deprecated = selects.with_or({
     "//conditions:default": [],
 })
 
-_w_no_unused_value = select({
-    ":linux": [
-        "-Wno-unused-value",
-    ],
-    "//conditions:default": [],
-})
-
 config_setting(
     name = "linux",
     constraint_values = [
@@ -741,7 +734,6 @@ boost_library(
 
 boost_library(
     name = "format",
-    copts = _w_no_unused_value,
     deps = [
         ":assert",
         ":config",

--- a/boost/boost.bzl
+++ b/boost/boost.bzl
@@ -21,8 +21,8 @@ srcs_patterns = [
 # Building boost results in many warnings for unused values. Downstream users
 # won't be interested, so just disable the warning.
 default_copts = select({
-    "@boost//:linux": ["-Wno-unused-value"],
-    "//conditions:default": [],
+    "@boost//:windows": [],
+    "//conditions:default": ["-Wno-unused"],
 })
 
 default_defines = select({


### PR DESCRIPTION
Right now on clang, a warning occurrs due to `-Wunused-typedef`. This PR broadens `-Wno-unused-value` to `-Wno-unused`. This will help suppress warnings related to unused parts of the code in boost.

Here is the original error:
```
Analyzing: 128 targets (113 packages loaded, 2178 targets configured)
INFO: Analyzed 128 targets (120 packages loaded, 10989 targets configured).
INFO: Found 128 targets...
[0 / 203] [Prepa] BazelWorkspaceStatusAction stable-status.txt
[31 / 214] Compiling external/boost/libs/log/src/core.cpp; 11s remote-cache, processwrapper-sandbox ... (23 actions, 22 running)
[63 / 214] Compiling external/boost/libs/log/src/text_file_backend.cpp; 14s remote-cache, processwrapper-sandbox ... (23 actions, 22 running)
[87 / 214] Compiling external/boost/libs/log/src/setup/settings_parser.cpp; 15s remote-cache, processwrapper-sandbox ... (23 actions, 22 running)
[123 / 217] Compiling external/boost/libs/log/src/setup/init_from_stream.cpp; 6s remote-cache, processwrapper-sandbox ... (22 actions, 20 running)
ERROR: /opt/bazel/clang11/outputRoot/4278ba43bff07aa4c43744152df55ae0/external/boost/BUILD.bazel:2150:14: C++ compilation of rule '@boost//:log' failed (Exit 1) clang-11 failed: error executing command /usr/bin/clang-11 -U_FORTIFY_SOURCE -fstack-protector -Wall -Wthread-safety -Wself-assign -fcolor-diagnostics -fno-omit-frame-pointer -g0 -O2 '-D_FORTIFY_SOURCE=1' -DNDEBUG -ffunction-sections ... (remaining 401 argument(s) skipped)
Use --sandbox_debug to see verbose messages from the sandbox
external/boost/libs/log/src/trivial.cpp:124:47: error: unused typedef 'level_names' [-Werror,-Wunused-local-typedef]
        typedef severity_level_names< CharT > level_names;
                                              ^
1 error generated.
INFO: Elapsed time: 153.250s, Critical Path: 25.51s
INFO: 118 processes: 10 remote cache hit, 108 processwrapper-sandbox.
FAILED: Build did NOT complete successfully
FAILED: Build did NOT complete successfully
```