### PR TITLE
Bump patch version of bzip2 for CVE-2019-12900

### DIFF
--- a/boost/boost.bzl
+++ b/boost/boost.bzl
@@ -190,12 +190,9 @@ def boost_deps():
         http_archive(
             name = "org_bzip_bzip2",
             build_file = "@com_github_nelhage_rules_boost//:BUILD.bzip2",
-            sha256 = "a2848f34fcd5d6cf47def00461fcb528a0484d8edef8208d6d2e2909dc61d9cd",
-            strip_prefix = "bzip2-1.0.6",
-            urls = [
-                "https://%s.dl.sourceforge.net/project/bzip2/bzip2-1.0.6.tar.gz" % (m,)
-                for m in SOURCEFORGE_MIRRORS
-            ],
+            sha256 = "ab5a03176ee106d3f0fa90e381da478ddae405918153cca248e682cd0c4a2269",
+            strip_prefix = "bzip2-1.0.8",
+            url = "https://sourceware.org/pub/bzip2/bzip2-1.0.8.tar.gz",
         )
 
     if "org_lzma_lzma" not in native.existing_rules():


### PR DESCRIPTION
Bump version of bzip2 to mitigate https://nvd.nist.gov/vuln/detail/CVE-2019-12900. I've tested it still builds fine.

Unfortunately, bzip2 isn't on sourceforge so I've had to use a different location for the download.