### PR TITLE
Fix boost spirit compilation issue if used as a single dependency.

### DIFF
--- a/BUILD.boost
+++ b/BUILD.boost
@@ -1435,7 +1435,6 @@ boost_library(
         ":limits",
         ":math",
         ":mpl",
-        ":multi_index",
         ":noncopyable",
         ":operators",
         ":range",
@@ -1647,10 +1646,15 @@ boost_library(
 boost_library(
     name = "spirit",
     deps = [
+        ":variant",
         ":optional",
         ":phoenix",
+        ":function",
+        ":foreach",
+        ":iostreams",
         ":range",
         ":ref",
+        ":tti",
         ":utility",
     ],
 )
@@ -2091,6 +2095,7 @@ boost_library(
     name = "phoenix",
     deps = [
         ":proto",
+        ":bind",
     ],
 )
 

--- a/test/BUILD
+++ b/test/BUILD
@@ -352,6 +352,16 @@ cc_test(
 )
 
 cc_test(
+    name = "spirit_test",
+    size = "small",
+    srcs = ["spirit_test.cc"],
+    copts = ["-std=c++14"],
+    deps = [
+        "@boost//:spirit",
+    ],
+)
+
+cc_test(
     name = "test_included_test",
     srcs = ["test_included_test.cc"],
     deps = [

--- a/test/spirit_test.cc
+++ b/test/spirit_test.cc
@@ -1,0 +1,19 @@
+// Example is based on num_list1.cpp from the boost.spirit repo:
+// https://github.com/boostorg/spirit/blob/develop/example/x3/num_list/num_list1.cpp
+
+#include <boost/spirit/home/x3.hpp>
+#include <string>
+
+namespace x3 = boost::spirit::x3;
+
+int main()
+{
+    std::string csl("1,2,3,4");
+
+    auto first = csl.begin();
+    auto last = csl.end();
+
+    auto res = x3::phrase_parse(first, last, x3::double_ >> *(',' >> x3::double_), x3::ascii::space);
+
+    return res && (first == last) ? 0 : 1;
+}


### PR DESCRIPTION
I just figured out that using boost spirit causes compilation errors. This fix:

- explicitly declares direct dependencies of spirit and phoenix
- removes the (unnecessary) dependency on multi_index from random, this dependency would otherwise cause a cyclic dependency on spirit. I am not 100% sure if there are still unnecessary dependency declarations left.
- provides a simple test case for spirit