### PR TITLE
Update boost to 1.72

### DIFF
--- a/BUILD.boost
+++ b/BUILD.boost
@@ -826,6 +826,7 @@ boost_library(
         ":config",
         ":integer",
         ":iterator",
+        ":mp11",
         ":mpl",
         ":ref",
         ":type_traits",

--- a/boost/boost.bzl
+++ b/boost/boost.bzl
@@ -224,11 +224,11 @@ def boost_deps():
             name = "boost",
             build_file = "@com_github_nelhage_rules_boost//:BUILD.boost",
             patch_cmds = ["rm -f doc/pdf/BUILD"],
-            sha256 = "d73a8da01e8bf8c7eda40b4c84915071a8c8a0df4a6734537ddde4a8580524ee",
-            strip_prefix = "boost_1_71_0",
+            sha256 = "59c9b274bc451cf91a9ba1dd2c7fdcaf5d60b1b3aa83f2c9fa143417cc660722",
+            strip_prefix = "boost_1_72_0",
             urls = [
-                "https://mirror.bazel.build/dl.bintray.com/boostorg/release/1.71.0/source/boost_1_71_0.tar.bz2",
-                "https://dl.bintray.com/boostorg/release/1.71.0/source/boost_1_71_0.tar.bz2",
+                "https://mirror.bazel.build/dl.bintray.com/boostorg/release/1.72.0/source/boost_1_72_0.tar.bz2",
+                "https://dl.bintray.com/boostorg/release/1.72.0/source/boost_1_72_0.tar.bz2",
             ],
         )
 


### PR DESCRIPTION
1.71 has a bug in https://www.boost.org/doc/libs/1_71_0/boost/math/tools/big_constant.hpp that is blocking us.