### PR TITLE
Remove dependency from the log library.

### DIFF
--- a/BUILD.boost
+++ b/BUILD.boost
@@ -2167,7 +2167,7 @@ boost_library(
     srcs = glob([
         "libs/log/src/setup/*.hpp",
         "libs/log/src/setup/*.cpp",
-    ]) + hdr_list("locale"),
+    ]) + ["boost/locale/utf.hpp"],
     copts = BOOST_LOG_CFLAGS + [
         "-Iexternal/boost/libs/log/src/",
     ],

--- a/BUILD.boost
+++ b/BUILD.boost
@@ -2129,7 +2129,6 @@ BOOST_LOG_DEPS = [
     ":date_time",
     ":filesystem",
     ":interprocess",
-    ":locale",
     ":parameter",
     ":phoenix",
     ":property_tree",
@@ -2168,7 +2167,7 @@ boost_library(
     srcs = glob([
         "libs/log/src/setup/*.hpp",
         "libs/log/src/setup/*.cpp",
-    ]),
+    ]) + hdr_list("locale"),
     copts = BOOST_LOG_CFLAGS + [
         "-Iexternal/boost/libs/log/src/",
     ],


### PR DESCRIPTION
The boost log library does not depend on the locale library.  Users
may want to have the former but not the latter in their project.  This
patch removes the gratuitous dependency.