### PR TITLE
Expose some private headers in Boost.Math

### DIFF
--- a/BUILD.boost
+++ b/BUILD.boost
@@ -1092,7 +1092,13 @@ boost_library(
     name = "math",
     hdrs = [
         "boost/cstdfloat.hpp",
+        # See https://github.com/boostorg/math/blob/boost-1.56.0/doc/overview/roadmap.qbk#L11-L14
+        "libs/math/include_private/boost/math/tools/remez.hpp",
+        "libs/math/include_private/boost/math/constants/generate.hpp",
+        "libs/math/include_private/boost/math/tools/solve.hpp",
+        "libs/math/include_private/boost/math/tools/test.hpp",
     ],
+    includes = ["libs/math/include_private"],
     deps = [
         ":array",
         ":assert",


### PR DESCRIPTION
From math release notes https://github.com/boostorg/math/blob/boost-1.56.0/doc/overview/roadmap.qbk#L11-L14

> [*Breaking change]: moved a number of non-core headers that are predominantly used for internal
> maintenance into `libs/math/include_private`.  The headers effected are `boost/math/tools/test_data.hpp`,
> `boost/math/tools/remez.hpp`, `boost/math/constants/generate.hpp`, `boost/math/tools/solve.hpp`,
> `boost/math/tools/test.hpp`.

I have been using some of this functionality and it might be worth exposing this via bazel for general use