### PR TITLE
Support boost 1.74.0

### DIFF
--- a/BUILD.boost
+++ b/BUILD.boost
@@ -297,14 +297,22 @@ boost_library(
 
 boost_library(
     name = "atomic",
+    srcs = select({
+        ":windows_x86_64": ["libs/atomic/src/wait_ops_windows.cpp"],
+        "//conditions:default": [],
+    }),
     hdrs = [
         "boost/memory_order.hpp",
     ],
+    copts = ["-Iexternal/boost/libs/atomic/src"],
+    exclude_src = ["libs/atomic/src/wait_ops_windows.cpp"],
     deps = [
         ":assert",
         ":config",
         ":cstdint",
+        ":predef",
         ":type_traits",
+        ":winapi",
     ],
 )
 
@@ -352,6 +360,7 @@ boost_library(
     linkopts = ["-lpthread"],
     deps = [
         ":bind",
+        ":cerrno",
         ":date_time",
         ":regex",
     ],
@@ -628,15 +637,12 @@ boost_library(
 
 boost_library(
     name = "date_time",
-    srcs = glob(["libs/date_time/src/**/*.cpp"]),
-    hdrs = glob(["libs/date_time/src/**/*.hpp"]),
     deps = [
         ":algorithm",
         ":io",
         ":lexical_cast",
         ":mpl",
         ":operators",
-        ":smart_ptr",
         ":static_assert",
         ":tokenizer",
         ":type_traits",
@@ -826,6 +832,7 @@ boost_library(
         ":config",
         ":integer",
         ":iterator",
+        ":mp11",
         ":mpl",
         ":ref",
         ":type_traits",
@@ -1210,6 +1217,15 @@ boost_library(
         ":throw_exception",
         ":type_traits",
         ":utility",
+    ],
+)
+
+boost_library(
+    name = "nowide",
+    deps = [
+        ":config",
+        ":filesystem",
+        ":version",
     ],
 )
 
@@ -1727,6 +1743,25 @@ boost_library(
 )
 
 boost_library(
+    name = "static_string",
+    deps = [
+        ":assert",
+        ":container_hash",
+        ":static_assert",
+        ":throw_exception",
+        ":utility",
+    ],
+)
+
+boost_library(
+    name = "stl_interfaces",
+    deps = [
+        ":assert",
+        ":config",
+    ],
+)
+
+boost_library(
     name = "system",
     deps = [
         ":assert",
@@ -1949,6 +1984,7 @@ boost_library(
         ":core",
         ":cstdint",
         ":detail",
+        ":io",
         ":preprocessor",
         ":static_assert",
         ":swap",
@@ -1992,6 +2028,7 @@ boost_library(
 boost_library(
     name = "variant2",
     deps = [
+        ":cstdint",
         ":mp11",
     ],
 )

--- a/boost/boost.bzl
+++ b/boost/boost.bzl
@@ -224,11 +224,11 @@ def boost_deps():
             name = "boost",
             build_file = "@com_github_nelhage_rules_boost//:BUILD.boost",
             patch_cmds = ["rm -f doc/pdf/BUILD"],
-            sha256 = "d73a8da01e8bf8c7eda40b4c84915071a8c8a0df4a6734537ddde4a8580524ee",
-            strip_prefix = "boost_1_71_0",
+            sha256 = "afff36d392885120bcac079148c177d1f6f7730ec3d47233aa51b0afa4db94a5",
+            strip_prefix = "boost_1_74_0",
             urls = [
-                "https://mirror.bazel.build/dl.bintray.com/boostorg/release/1.71.0/source/boost_1_71_0.tar.bz2",
-                "https://dl.bintray.com/boostorg/release/1.71.0/source/boost_1_71_0.tar.bz2",
+                # "https://mirror.bazel.build/dl.bintray.com/boostorg/release/1.74.0/source/boost_1_74_0.tar.gz",
+                "https://dl.bintray.com/boostorg/release/1.74.0/source/boost_1_74_0.tar.gz",
             ],
         )
 

--- a/test/BUILD
+++ b/test/BUILD
@@ -31,7 +31,6 @@ cc_test(
     srcs = ["asio_test.cc"],
     deps = [
         "@boost//:asio",
-        "@boost//:date_time",
     ],
 )
 
@@ -163,6 +162,15 @@ cc_test(
 )
 
 cc_test(
+    name = "filesystem_test",
+    size = "small",
+    srcs = ["filesystem_test.cc"],
+    deps = [
+        "@boost//:filesystem",
+    ],
+)
+
+cc_test(
     name = "foreach_test",
     size = "small",
     srcs = ["foreach_test.cc"],
@@ -258,6 +266,15 @@ cc_test(
     srcs = ["numeric_conversion_test.cc"],
     deps = [
         "@boost//:numeric_conversion",
+    ],
+)
+
+cc_test(
+    name = "nowide_test",
+    size = "small",
+    srcs = ["nowide_test.cc"],
+    deps = [
+        "@boost//:nowide",
     ],
 )
 
@@ -501,5 +518,30 @@ cc_test(
     copts = ["-std=c++14"],
     deps = [
         "@boost//:variant2",
+    ],
+)
+
+cc_test(
+    name = "static_string_test",
+    srcs = ["static_string_test.cc"],
+    deps = [
+        "@boost//:static_string",
+    ],
+)
+
+cc_test(
+    name = "stl_interfaces_test",
+    srcs = ["stl_interfaces_test.cc"],
+    deps = [
+        "@boost//:stl_interfaces",
+    ],
+    copts = ["-std=c++1y"],
+)
+
+cc_test(
+    name = "date_time_test",
+    srcs = ["date_time_test.cc"],
+    deps = [
+        "@boost//:date_time",
     ],
 )

--- a/test/bind_test.cc
+++ b/test/bind_test.cc
@@ -1,4 +1,4 @@
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 
 int f(int a, int b)
 {

--- a/test/date_time_test.cc
+++ b/test/date_time_test.cc
@@ -1,0 +1,8 @@
+#include <boost/date_time.hpp>
+
+int main()
+{
+  std::string ud("20200131");
+  boost::gregorian::date d1(boost::gregorian::from_undelimited_string(ud));
+  return to_iso_extended_string(d1) == "2020-01-31" ? 0 : 1;
+}

--- a/test/filesystem_test.cc
+++ b/test/filesystem_test.cc
@@ -1,0 +1,9 @@
+#include <boost/filesystem.hpp>
+
+int main(int argc, char* argv[])
+{
+  boost::filesystem::path p;
+  p /= "comp1";
+  p /= "comp2";
+  return p.compare(std::string{"comp1/comp2"});
+}

--- a/test/nowide_test.cc
+++ b/test/nowide_test.cc
@@ -1,0 +1,22 @@
+#include <boost/nowide/args.hpp>
+#include <boost/nowide/convert.hpp>
+#include <boost/nowide/cstdio.hpp>
+#include <boost/nowide/cstdlib.hpp>
+#include <boost/nowide/filebuf.hpp>
+#include <boost/nowide/filesystem.hpp>
+#include <boost/nowide/fstream.hpp>
+#include <boost/nowide/iostream.hpp>
+#include <boost/nowide/iostream.hpp>
+#include <boost/nowide/replacement.hpp>
+#include <boost/nowide/stackstring.hpp>
+#include <boost/nowide/stackstring.hpp>
+#include <boost/nowide/stat.hpp>
+#include <boost/nowide/utf8_codecvt.hpp>
+
+int main(int argc, char **argv)
+{
+  std::string hello = "\xd7\xa9\xd7\x9c\xd7\x95\xd7\x9d";
+  std::wstring whello = boost::nowide::widen(hello);
+  boost::nowide::nowide_filesystem();
+  return boost::nowide::narrow(whello) == hello ? 0 : 1;
+}

--- a/test/static_string_test.cc
+++ b/test/static_string_test.cc
@@ -1,0 +1,7 @@
+#include <boost/static_string/static_string.hpp>
+
+int main()
+{
+  boost::static_string<5> s1("UVXYZ", 3);
+  return s1 == "UVX" ? 0 : 1;
+}

--- a/test/stl_interfaces_test.cc
+++ b/test/stl_interfaces_test.cc
@@ -1,0 +1,51 @@
+#include <boost/stl_interfaces/iterator_interface.hpp>
+
+#include <algorithm>
+#include <array>
+#include <vector>
+
+template <typename Pred>
+struct filtered_int_iterator
+    : boost::stl_interfaces::iterator_interface<
+          filtered_int_iterator<Pred>, std::bidirectional_iterator_tag, int> {
+  filtered_int_iterator() : it_(nullptr) {}
+  filtered_int_iterator(int *it, int *last, Pred pred)
+      : it_(it), last_(last), pred_(std::move(pred)) {
+    it_ = std::find_if(it_, last_, pred_);
+  }
+
+  filtered_int_iterator &operator++() {
+    it_ = std::find_if(std::next(it_), last_, pred_);
+    return *this;
+  }
+
+  int *base() const { return it_; }
+
+private:
+  friend boost::stl_interfaces::access;
+  int *&base_reference() noexcept { return it_; }
+  int *base_reference() const noexcept { return it_; }
+
+  int *it_;
+  int *last_;
+  Pred pred_;
+};
+
+template <typename Pred>
+filtered_int_iterator<Pred> make_filtered_int_iterator(int *it, int *last, Pred pred) {
+  return filtered_int_iterator<Pred>(it, last, std::move(pred));
+}
+
+int main() {
+  std::array<int, 8> ints = {{0, 1, 2, 3, 4, 5, 6, 7}};
+  int *const ints_first = ints.data();
+  int *const ints_last = ints.data() + ints.size();
+
+  auto even = [](int x) { return (x % 2) == 0; };
+  auto first = make_filtered_int_iterator(ints_first, ints_last, even);
+  auto last = make_filtered_int_iterator(ints_last, ints_last, even);
+
+  std::vector<int> ints_copy;
+  std::copy(first, last, std::back_inserter(ints_copy));
+  return ints_copy == (std::vector<int>{0, 2, 4, 6}) ? 0 : 1;
+}


### PR DESCRIPTION
date_time became all-inline in 1.73 (see https://github.com/boostorg/date_time/issues/134) so the build file changes will probably cause issues for anyone using 1.72 and below.