### PR TITLE
Use local_defines instead of defines where possible

### DIFF
--- a/BUILD.boost
+++ b/BUILD.boost
@@ -1525,9 +1525,6 @@ boost_library(
     hdrs = [
         "boost/cregex.hpp",
     ],
-    defines = [
-        "BOOST_FALLTHROUGH",
-    ],
     deps = [
         ":assert",
         ":config",
@@ -1782,7 +1779,7 @@ boost_library(
         ],
         ":windows_x86_64": [],
     }),
-    defines = select({
+    local_defines = select({
         ":linux_arm": [],
         ":linux_ppc": [],
         ":linux_x86_64": [],
@@ -2160,7 +2157,7 @@ cc_library(
     srcs = ["libs/log/src/dump_ssse3.cpp"] + hdr_list("log"),
     hdrs = [],
     copts = ["-msse4.2"],
-    defines = BOOST_LOG_DEFINES,
+    local_defines = BOOST_LOG_DEFINES,
     includes = [],
     licenses = ["notice"],
     linkopts = [],
@@ -2177,7 +2174,7 @@ boost_library(
     copts = BOOST_LOG_CFLAGS + [
         "-Iexternal/boost/libs/log/src/",
     ],
-    defines = BOOST_LOG_DEFINES,
+    local_defines = BOOST_LOG_DEFINES,
     exclude_src = [
         "libs/log/src/dump_avx2.cpp",
         "libs/log/src/dump_ssse3.cpp",

--- a/boost/boost.bzl
+++ b/boost/boost.bzl
@@ -46,6 +46,7 @@ def boost_library(
         name,
         boost_name = None,
         defines = None,
+        local_defines = None,
         includes = None,
         hdrs = None,
         srcs = None,
@@ -61,6 +62,9 @@ def boost_library(
 
     if defines == None:
         defines = []
+
+    if local_defines == None:
+        local_defines = []
 
     if includes == None:
         includes = []
@@ -85,6 +89,7 @@ def boost_library(
         visibility = visibility,
         defines = default_defines + defines,
         includes = includes_list(boost_name) + includes,
+        local_defines = local_defines,
         hdrs = hdr_list(boost_name, exclude_hdr) + hdrs,
         srcs = srcs_list(boost_name, exclude_src) + srcs,
         deps = deps,


### PR DESCRIPTION
With the exception of asio, there are no public defines required for users of boost libraries.