### PR TITLE
Android Build Compatibility

### DIFF
--- a/BUILD.boost
+++ b/BUILD.boost
@@ -25,7 +25,6 @@ config_setting(
     visibility = ["//visibility:public"],
 )
 
-
 config_setting(
     name = "osx",
     constraint_values = [
@@ -113,6 +112,24 @@ config_setting(
     visibility = ["//visibility:public"],
 )
 
+config_setting(
+    name = "android_arm",
+    constraint_values = [
+        "@bazel_tools//platforms:android",
+        "@bazel_tools//platforms:arm",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
+    name = "android_aarch64",
+    constraint_values = [
+        "@bazel_tools//platforms:android",
+        "@bazel_tools//platforms:aarch64",
+    ],
+    visibility = ["//visibility:public"],
+)
+
 # Rename .asm to .S so that it will be handled with the C preprocessor.
 [copy_file(
     name = "rename_%s" % name,
@@ -124,13 +141,13 @@ config_setting(
     "ontop",
 ]]
 
-BOOST_CTX_ASM_SOURCES = select({
-    ":linux_aarch64": [
+BOOST_CTX_ASM_SOURCES = selects.with_or({
+    (":linux_aarch64", ":android_aarch64"): [
         "libs/context/src/asm/jump_arm64_aapcs_elf_gas.S",
         "libs/context/src/asm/make_arm64_aapcs_elf_gas.S",
         "libs/context/src/asm/ontop_arm64_aapcs_elf_gas.S",
     ],
-    ":linux_arm": [
+    (":linux_arm", ":android_arm"): [
         "libs/context/src/asm/jump_arm_aapcs_elf_gas.S",
         "libs/context/src/asm/make_arm_aapcs_elf_gas.S",
         "libs/context/src/asm/ontop_arm_aapcs_elf_gas.S",
@@ -165,8 +182,8 @@ BOOST_CTX_ASM_SOURCES = select({
 
 boost_library(
     name = "context",
-    srcs = BOOST_CTX_ASM_SOURCES + select({
-        ":linux": [
+    srcs = BOOST_CTX_ASM_SOURCES + selects.with_or({
+        (":linux", ":android"): [
             "libs/context/src/posix/stack_traits.cpp",
         ],
         ":osx": [
@@ -338,7 +355,10 @@ BOOST_ATOMIC_DEPS = [
 
 cc_library(
     name = "atomic_sse",
-    srcs = BOOST_ATOMIC_SSE_SRCS + glob(["libs/atomic/src/*.hpp", "boost/atomic/detail/*.hpp"]),
+    srcs = BOOST_ATOMIC_SSE_SRCS + glob([
+        "libs/atomic/src/*.hpp",
+        "boost/atomic/detail/*.hpp",
+    ]),
     copts = [
         "-msse2",
         "-msse4.1",
@@ -627,6 +647,9 @@ boost_library(
 )
 
 BOOST_CORO_SRCS = select({
+    ":android": [
+        "libs/coroutine/src/posix/stack_traits.cpp",
+    ],
     ":linux": [
         "libs/coroutine/src/posix/stack_traits.cpp",
     ],
@@ -1086,6 +1109,10 @@ BOOST_LOCALE_COMMON_SOURCES = glob(
     ],
 )
 
+BOOST_LOCALE_STD_SOURCES = BOOST_LOCALE_COMMON_SOURCES + [
+    "libs/locale/src/util/iconv.hpp",
+]
+
 BOOST_LOCALE_POSIX_SOURCES = BOOST_LOCALE_COMMON_SOURCES + [
     "libs/locale/src/util/iconv.hpp",
 ] + glob([
@@ -1098,6 +1125,12 @@ BOOST_LOCALE_WIN32_SOURCES = BOOST_LOCALE_COMMON_SOURCES + glob([
     "libs/locale/src/win32/*.hpp",
 ])
 
+BOST_LOCALE_STD_COPTS = [
+    "-DBOOST_LOCALE_NO_POSIX_BACKEND=1",
+    "-DBOOST_LOCALE_NO_WINAPI_BACKEND",
+    "-DBOOST_LOCALE_WITH_ICONV",
+]
+
 BOOST_LOCALE_POSIX_COPTS = [
     "-DBOOST_LOCALE_WITH_ICONV",
     "-DBOOST_LOCALE_NO_WINAPI_BACKEND",
@@ -1108,6 +1141,7 @@ BOOST_LOCALE_WIN32_COPTS = []
 boost_library(
     name = "locale",
     srcs = select({
+        ":android": BOOST_LOCALE_STD_SOURCES,
         ":linux_arm": BOOST_LOCALE_POSIX_SOURCES,
         ":linux_ppc": BOOST_LOCALE_POSIX_SOURCES,
         ":linux_x86_64": BOOST_LOCALE_POSIX_SOURCES,
@@ -1115,6 +1149,7 @@ boost_library(
         ":windows_x86_64": BOOST_LOCALE_WIN32_SOURCES,
     }),
     copts = select({
+        ":android": BOST_LOCALE_STD_COPTS,
         ":linux_arm": BOOST_LOCALE_POSIX_COPTS,
         ":linux_ppc": BOOST_LOCALE_POSIX_COPTS,
         ":linux_x86_64": BOOST_LOCALE_POSIX_COPTS,
@@ -1344,6 +1379,10 @@ boost_library(
     ]) + [
         "boost/numeric/odeint.hpp",
     ],
+    linkopts = select({
+        "@boost//:android": ["-lm"],
+        "//conditions:default": [],
+    }),
     deps = [
         ":fusion",
         ":lexical_cast",
@@ -1495,6 +1534,10 @@ boost_library(
 
 boost_library(
     name = "qvm",
+    linkopts = select({
+        "@boost//:android": ["-lm"],
+        "//conditions:default": [],
+    }),
     deps = [
         ":assert",
         ":core",
@@ -1740,6 +1783,10 @@ boost_library(
 )
 
 BOOST_STACKTRACE_SOURCES = select({
+    ":android": [
+        "libs/stacktrace/src/basic.cpp",
+        #"libs/stacktrace/src/noop.cpp",
+    ],
     ":linux_arm": [
         "libs/stacktrace/src/basic.cpp",
         "libs/stacktrace/src/noop.cpp",
@@ -2368,9 +2415,9 @@ boost_library(
     deps = [
         ":config",
         ":container",
-        ":system",
         ":shared_ptr",
         ":smart_ptr",
+        ":system",
         ":throw_exception",
         ":utility",
     ],

--- a/BUILD.boost
+++ b/BUILD.boost
@@ -18,6 +18,15 @@ config_setting(
 )
 
 config_setting(
+    name = "android",
+    constraint_values = [
+        "@bazel_tools//platforms:android",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+
+config_setting(
     name = "osx",
     constraint_values = [
         "@bazel_tools//platforms:osx",
@@ -397,7 +406,10 @@ boost_library(
         ],
         "//conditions:default": [],
     }),
-    linkopts = ["-lpthread"],
+    linkopts = select({
+        ":android": [],
+        "//conditions:default": ["-lpthread"],
+    }),
     deps = [
         ":bind",
         ":cerrno",
@@ -1832,8 +1844,8 @@ boost_library(
 
 boost_library(
     name = "thread",
-    srcs = select({
-        ":linux": [
+    srcs = selects.with_or({
+        (":linux", ":android"): [
             "libs/thread/src/pthread/once.cpp",
             "libs/thread/src/pthread/thread.cpp",
         ],
@@ -1847,8 +1859,8 @@ boost_library(
             "libs/thread/src/win32/tss_pe.cpp",
         ],
     }),
-    hdrs = select({
-        ":linux": [
+    hdrs = selects.with_or({
+        (":linux", ":android"): [
             "libs/thread/src/pthread/once_atomic.cpp",
         ],
         ":osx": [
@@ -1864,6 +1876,7 @@ boost_library(
             "-lpthread",
         ],
         ":windows_x86_64": [],
+        ":android": [],
     }),
     local_defines = select({
         ":linux_arm": [],

--- a/BUILD.lzma
+++ b/BUILD.lzma
@@ -30,9 +30,15 @@ config_setting(
     constraint_values = ["@bazel_tools//platforms:windows"],
 )
 
+config_setting(
+    name = "android",
+    constraint_values = ["@bazel_tools//platforms:android"],
+)
+
 copy_file(
     name = "copy_config",
     src = select({
+        ":android": "@com_github_nelhage_rules_boost//:config.lzma-linux.h",
         ":linux": "@com_github_nelhage_rules_boost//:config.lzma-linux.h",
         ":osx_arm64": "@com_github_nelhage_rules_boost//:config.lzma-osx-arm64.h",
         ":osx_x86_64": "@com_github_nelhage_rules_boost//:config.lzma-osx-x86_64.h",
@@ -158,7 +164,10 @@ cc_library(
     includes = [
         "src/liblzma/api",
     ],
-    linkopts = ["-lpthread"],
+    linkopts = select({
+        ":android": [],
+        "//conditions:default": ["-lpthread"],
+    }),
     linkstatic = select({
         ":windows": True,
         "//conditions:default": False,

--- a/boost/boost.bzl
+++ b/boost/boost.bzl
@@ -156,6 +156,7 @@ def boost_so_library(
             "libs/%s/**" % boost_name,
         ]),
         deps = deps + select({
+            "@boost//:android": [":_imported_%s.so" % name],
             "@boost//:linux": [":_imported_%s.so" % name],
             "@boost//:osx": [":_imported_%s.dylib" % name],
             "@boost//:windows": [":_imported_%s.dll" % name],

--- a/test/BUILD
+++ b/test/BUILD
@@ -582,3 +582,11 @@ cc_test(
         "@boost//:pfr",
     ],
 )
+
+platform(
+    name = "android",
+    constraint_values = [
+        "@platforms//os:android",
+        "@platforms//cpu:aarch64",
+    ],
+)


### PR DESCRIPTION
This adds android compatibility across the board.  If you add an android_ndk rule to test/WORKSPACE and build with appropriate flags (`--crosstool_top=//external:android/crosstool --cpu arm64-v8a --fat_apk_cpu=arm64-v8a --extra_toolchains=@androidndk//:all --host_crosstool_top=@bazel_tools//tools/cpp:toolchain --platforms=//:android`) it will build all the tests successfully (if not run them...)

The biggest change was removing `-lpthread` in several places, along with adding :android to appropriate selects.