### PR TITLE
update boost archive patch to include a PowerShell command for Windows users

### DIFF
--- a/boost/boost.bzl
+++ b/boost/boost.bzl
@@ -226,6 +226,7 @@ def boost_deps():
             name = "boost",
             build_file = "@com_github_nelhage_rules_boost//:BUILD.boost",
             patch_cmds = ["rm -f doc/pdf/BUILD"],
+            patch_cmds_win = ["Remove-Item -Force doc/pdf/BUILD"],
             sha256 = "aeb26f80e80945e82ee93e5939baebdca47b9dee80a07d3144be1e1a6a66dd6a",
             strip_prefix = "boost_1_75_0",
             urls = [


### PR DESCRIPTION
### Problem
If Bazel is installed on Windows without a Bash shell to use, any of the boost dependencies will throw an error like this:
> Error in fail: Error applying patch command rm -f doc/pdf/BUILD:
> /usr/bin/bash: rm: command not found

The easy solution is to force Bazel to use a Windows-based Bash shell like Msys2 or Git Bash but as stated [here](https://docs.bazel.build/versions/master/windows.html#running-bazel-msys2-shell-vs-command-prompt-vs-powershell):
> As of 2020-01-15, we do not recommend running Bazel from bash – either from MSYS2 shell, or Git Bash, or Cygwin, or any other Bash variant. While Bazel may work for most use cases, some things are broken, like interrupting the build with Ctrl+C from MSYS2). 
### Solution
Include a patch/cleanup script for Windows Powershell that allows Bazel on Windows to perform Boost Library importing without error.