### PR TITLE
Update boringssl to most recent commit in master-with-bazel branch

### DIFF
--- a/boost/boost.bzl
+++ b/boost/boost.bzl
@@ -235,10 +235,10 @@ def boost_deps():
         )
 
     if "openssl" not in native.existing_rules():
-        # https://github.com/google/boringssl/archive/57c37a99b6a9f523b10344b7b6b93ce9ad1da795.zip
+        # https://github.com/google/boringssl/archive/b3d98af9c80643b0a36d495693cc0e669181c0af.zip
         http_archive(
             name = "openssl",
-            sha256 = "84afcec7a9ce3a72fde95dc42d52bc6662df5976bdd3d440b3e7e7543b7031b9",
-            strip_prefix = "boringssl-57c37a99b6a9f523b10344b7b6b93ce9ad1da795",
-            url = "https://github.com/google/boringssl/archive/57c37a99b6a9f523b10344b7b6b93ce9ad1da795.tar.gz",
+            sha256 = "17f5e63875d592ac8f596a6c3d579978a7bf943247c1f8cbc8051935ea42b3e5",
+            strip_prefix = "boringssl-b3d98af9c80643b0a36d495693cc0e669181c0af",
+            url = "https://github.com/google/boringssl/archive/b3d98af9c80643b0a36d495693cc0e669181c0af.tar.gz",
         )


### PR DESCRIPTION
I am trying to keep the boringssl implementation in this repo somewhat up to date; I last updated this in #195 exactly six months ago. This pull request updates the boringssl implementation to commit https://github.com/google/boringssl/commit/b3d98af9c80643b0a36d495693cc0e669181c0af which is the tip of the upstream boringssl `master-with-bazel` branch.

I tested this locally with a personal project that uses the `boost::asio` implementation from `rules_boost` and I didn't have any problems or build errors. As far as I'm aware there are no critical security updates made to boringssl between now and the last time we updated, it's just good to not let this get to too old.