### PR TITLE
Build boost::beast using std::string_view instead of boost::string_view

### DIFF
--- a/BUILD.boost
+++ b/BUILD.boost
@@ -456,6 +456,7 @@ boost_library(
 
 boost_library(
     name = "beast",
+    defines = ["BOOST_BEAST_USE_STD_STRING_VIEW"],
     deps = [
         ":asio",
         ":config",


### PR DESCRIPTION
This builds `boost::beast` so that `boost::beast::string_view` is an alias for `std::string_view` (instead of being an alias to `boost::string_view`). This simplifies interaction with the STL in many cases.

This should work with any compiler that supports `std::string_view`, I personally tested this on some Linux machines (Debian + Fedora) using Clang/GCC and it works for me.