### PR TITLE
Remove ubuntu1604 from presubmit.yml

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -1,28 +1,22 @@
 ---
 tasks:
-  ubuntu1604:
-    working_directory: test
-    build_targets:
-    - "..."
-    test_targets:
-    - "..."
   ubuntu1804:
     working_directory: test
     build_targets:
-    - "..."
+    - "//..."
     test_targets:
-    - "..."
+    - "//..."
   macos:
     working_directory: test
     build_targets:
-    - "..."
+    - "//..."
     test_targets:
-    - "..."
+    - "//..."
   windows:
     working_directory: test
     environment:
       BAZEL_VC: "C:\\Program Files (x86)\\Microsoft Visual Studio\\2017\\BuildTools\\VC"
     build_targets:
-    - "..."
+    - "//..."
     test_targets:
-    - "..."
+    - "//..."


### PR DESCRIPTION
Ubuntu 16.04 is end-of-life, we're going to remove it from Bazel CI.

If you like you can add testing on `ubuntu2004` platform which we also support.