### PR TITLE
Bugfix for boost.locale compilation error on Jetson AGX Xavier

### DIFF
--- a/BUILD.boost
+++ b/BUILD.boost
@@ -1143,6 +1143,7 @@ boost_library(
     srcs = select({
         ":android": BOOST_LOCALE_STD_SOURCES,
         ":linux_arm": BOOST_LOCALE_POSIX_SOURCES,
+        ":linux_aarch64": BOOST_LOCALE_POSIX_SOURCES,
         ":linux_ppc": BOOST_LOCALE_POSIX_SOURCES,
         ":linux_x86_64": BOOST_LOCALE_POSIX_SOURCES,
         ":osx": BOOST_LOCALE_POSIX_SOURCES,
@@ -1151,6 +1152,7 @@ boost_library(
     copts = select({
         ":android": BOST_LOCALE_STD_COPTS,
         ":linux_arm": BOOST_LOCALE_POSIX_COPTS,
+        ":linux_aarch64": BOOST_LOCALE_POSIX_COPTS,
         ":linux_ppc": BOOST_LOCALE_POSIX_COPTS,
         ":linux_x86_64": BOOST_LOCALE_POSIX_COPTS,
         ":osx": BOOST_LOCALE_POSIX_COPTS,


### PR DESCRIPTION
Otherwise, bazel build [Boost.Locale hello.cpp]
(https://www.boost.org/doc/libs/1_68_0/libs/locale/doc/html/hello_8cpp-example.html)

With BUILD file

```
load("@rules_cc//cc:defs.bzl", "cc_binary")

package(default_visibility = ["//visibility:public"])

cc_binary(
    name = "hello",
    srcs = ["hello.cpp"],
    deps = [
        "@boost//:locale",
    ],
)
```

will fail:

```
/home/story/.cache/bazel/_bazel_story/a35e351a941ea5c07bfe65d756777289/external/boost/BUILD.bazel:1049:14: Configurable attribute "copts" doesn't match this configuration (would a default condition help?).
Conditions checked:
 @boost//:linux_arm
 @boost//:linux_ppc
 @boost//:linux_x86_64
 @boost//:osx_x86_64
 @boost//:windows_x86_64
```