### PR TITLE
Adding missing dependency for spirit

### DIFF
--- a/BUILD.boost
+++ b/BUILD.boost
@@ -1801,6 +1801,7 @@ boost_library(
 boost_library(
     name = "spirit",
     deps = [
+        ":endian",
         ":foreach",
         ":function",
         ":iostreams",


### PR DESCRIPTION
The spirit library depends on the endian package.