### PR TITLE
Add a flag to use std::string_view for beast::string_view

### DIFF
--- a/BUILD.boost
+++ b/BUILD.boost
@@ -489,6 +489,18 @@ boost_library(
     name = "assert",
 )
 
+bool_flag(
+    name = "beast_use_std_string_view",
+    build_setting_default = False,
+)
+
+config_setting(
+    name = "beast_std_string_view",
+    flag_values = {
+        ":beast_use_std_string_view": "True",
+    },
+)
+
 boost_library(
     name = "beast",
     srcs = [
@@ -496,7 +508,10 @@ boost_library(
     ],
     defines = [
         "BOOST_BEAST_SEPARATE_COMPILATION",
-    ],
+    ] + select({
+        ":beast_std_string_view": ["BOOST_BEAST_USE_STD_STRING_VIEW"],
+        "//conditions:default": [],
+    }),
     deps = [
         ":asio",
         ":config",
@@ -1914,7 +1929,7 @@ boost_library(
 boost_library(
     name = "static_assert",
     hdrs = [
-        "boost/detail/workaround.hpp"
+        "boost/detail/workaround.hpp",
     ],
 )
 
@@ -1963,10 +1978,10 @@ boost_library(
     hdrs = ["boost/exception/exception.hpp"],
     deps = [
         ":assert",
-        ":current_function",
-        ":detail",
         ":config",
         ":cstdint",
+        ":current_function",
+        ":detail",
     ],
 )
 

--- a/README.md
+++ b/README.md
@@ -44,3 +44,11 @@ OpenSSL's libssl at `@openssl//:ssl`.
 To enable io\_uring for asio, use `--@boost//:asio_has_io_uring`.
 Optionally, pass`--@boost//:asio_disable_epoll` to use io\_uring
 for all operations.
+
+## Beast
+
+Boost Beast uses `beast::string_view` for things like request/response headers,
+which by default is a type alias of `boost::string_view`. If you're using a
+C++17 compiler that supports `std::string_view` you can use
+`--@boost//:beast_use_std_string_view` to make `beast::string_view` instead be a
+type alias of `std::string_view`.


### PR DESCRIPTION
This is pretty self explanatory, and I've added a note to the README. There are also two unrelated formatting changes my editor automatically applied from buildifier, I can split this out if necessary.