### PR TITLE
Use defines instead of copts for zlib/zstd

### DIFF
--- a/BUILD.zlib
+++ b/BUILD.zlib
@@ -36,9 +36,9 @@ cc_library(
         "@boost//:windows": [],
         "//conditions:default": ["-Wno-shift-negative-value"],
     }),
-    defines = select({
+    includes = ["."],
+    local_defines = select({
         "@boost//:windows": [],
         "//conditions:default": ["Z_HAVE_UNISTD_H"],
     }),
-    includes = ["."],
 )

--- a/BUILD.zlib
+++ b/BUILD.zlib
@@ -34,10 +34,11 @@ cc_library(
     hdrs = ["zlib.h"],
     copts = select({
         "@boost//:windows": [],
-        "//conditions:default": [
-            "-Wno-shift-negative-value",
-            "-DZ_HAVE_UNISTD_H",
-        ],
+        "//conditions:default": ["-Wno-shift-negative-value"],
+    }),
+    defines = select({
+        "@boost//:windows": [],
+        "//conditions:default": ["Z_HAVE_UNISTD_H"],
     }),
     includes = ["."],
 )

--- a/BUILD.zstd
+++ b/BUILD.zstd
@@ -22,14 +22,14 @@ cc_library(
         "lib/zstd.h",
         "lib/zstd_errors.h",
     ],
-    defines = [
-        "ZSTD_LEGACY_SUPPORT=4",
-        "ZSTD_MULTITHREAD",
-        "XXH_NAMESPACE=ZSTD_",
-    ],
     includes = ["lib"],
     linkopts = [
         "-pthread",
+    ],
+    local_defines = [
+        "ZSTD_LEGACY_SUPPORT=4",
+        "ZSTD_MULTITHREAD",
+        "XXH_NAMESPACE=ZSTD_",
     ],
     visibility = ["//visibility:public"],
 )

--- a/BUILD.zstd
+++ b/BUILD.zstd
@@ -22,10 +22,10 @@ cc_library(
         "lib/zstd.h",
         "lib/zstd_errors.h",
     ],
-    copts = [
-        "-DZSTD_LEGACY_SUPPORT=4",
-        "-DZSTD_MULTITHREAD",
-        "-DXXH_NAMESPACE=ZSTD_",
+    defines = [
+        "ZSTD_LEGACY_SUPPORT=4",
+        "ZSTD_MULTITHREAD",
+        "XXH_NAMESPACE=ZSTD_",
     ],
     includes = ["lib"],
     linkopts = [


### PR DESCRIPTION
This is just a pedantic style fix for the zlib/zstd build files, `cc_library` rules should declare preprocessor defines using `defines` instead of `copts`.