### PR TITLE
Add support for iOS, watchOS, and tvOS

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -3,5 +3,8 @@ exports_files([
     "config.lzma-linux.h",
     "config.lzma-osx-arm64.h",
     "config.lzma-osx-x86_64.h",
+    "config.lzma-ios-arm64.h",
+    "config.lzma-ios-armv7.h",
+    "config.lzma-ios-i386.h",
     "config.lzma-windows.h",
 ])

--- a/BUILD.boost
+++ b/BUILD.boost
@@ -4,7 +4,7 @@ load("@bazel_skylib//rules:common_settings.bzl", "bool_flag")
 load("@com_github_nelhage_rules_boost//:boost/boost.bzl", "boost_library", "boost_so_library", "hdr_list")
 
 _w_no_deprecated = selects.with_or({
-    (":linux", ":osx"): [
+    (":linux", ":osx", ":ios", ":watchos", ":tvos"): [
         "-Wno-deprecated-declarations",
     ],
     "//conditions:default": [],
@@ -30,6 +30,30 @@ config_setting(
     name = "osx",
     constraint_values = [
         "@bazel_tools//platforms:osx",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
+    name = "ios",
+    constraint_values = [
+        "@bazel_tools//platforms:ios",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
+    name = "watchos",
+    constraint_values = [
+        "@platforms//os:watchos",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
+    name = "tvos",
+    constraint_values = [
+        "@platforms//os:tvos",
     ],
     visibility = ["//visibility:public"],
 )
@@ -163,16 +187,7 @@ BOOST_CTX_ASM_SOURCES = selects.with_or({
         "libs/context/src/asm/make_x86_64_sysv_elf_gas.S",
         "libs/context/src/asm/ontop_x86_64_sysv_elf_gas.S",
     ],
-    ":osx_arm64": [
-        "libs/context/src/asm/jump_arm64_aapcs_macho_gas.S",
-        "libs/context/src/asm/make_arm64_aapcs_macho_gas.S",
-        "libs/context/src/asm/ontop_arm64_aapcs_macho_gas.S",
-    ],
-    ":osx_x86_64": [
-        "libs/context/src/asm/jump_x86_64_sysv_macho_gas.S",
-        "libs/context/src/asm/make_x86_64_sysv_macho_gas.S",
-        "libs/context/src/asm/ontop_x86_64_sysv_macho_gas.S",
-    ],
+    (":osx", ":ios", ":watchos", ":tvos") : ["apple_ctx_asm_sources"],
     ":windows_x86_64": [
         "libs/context/src/asm/make_x86_64_ms_pe_masm.S",
         "libs/context/src/asm/jump_x86_64_ms_pe_masm.S",
@@ -181,13 +196,31 @@ BOOST_CTX_ASM_SOURCES = selects.with_or({
     "//conditions:default": [],
 })
 
+filegroup(
+    name = "apple_ctx_asm_sources",
+    srcs = select({
+        "@bazel_tools//platforms:aarch64": [
+            "libs/context/src/asm/jump_arm64_aapcs_macho_gas.S",
+            "libs/context/src/asm/make_arm64_aapcs_macho_gas.S",
+            "libs/context/src/asm/ontop_arm64_aapcs_macho_gas.S",
+        ],
+        "@bazel_tools//platforms:arm": [
+            "libs/context/src/asm/jump_arm_aapcs_macho_gas.S",
+            "libs/context/src/asm/make_arm_aapcs_macho_gas.S",
+            "libs/context/src/asm/ontop_arm_aapcs_macho_gas.S",
+        ],
+        "@bazel_tools//platforms:x86_64": [
+            "libs/context/src/asm/jump_x86_64_sysv_macho_gas.S",
+            "libs/context/src/asm/make_x86_64_sysv_macho_gas.S",
+            "libs/context/src/asm/ontop_x86_64_sysv_macho_gas.S",
+        ],
+    })
+)
+
 boost_library(
     name = "context",
     srcs = BOOST_CTX_ASM_SOURCES + selects.with_or({
-        (":linux", ":android"): [
-            "libs/context/src/posix/stack_traits.cpp",
-        ],
-        ":osx": [
+        (":linux", ":android", ":osx", ":ios", ":watchos", ":tvos"): [
             "libs/context/src/posix/stack_traits.cpp",
         ],
         ":windows_x86_64": [
@@ -250,13 +283,8 @@ boost_library(
         "//conditions:default": [],
     }),
     exclude_src = ["libs/fiber/src/numa/**/*.cpp"],
-    linkopts = select({
-        ":linux": [
-            "-lpthread",
-        ],
-        ":osx": [
-            "-lpthread",
-        ],
+    linkopts = selects.with_or({
+        (":linux", ":osx", ":ios", ":watchos", ":tvos"): ["-lpthread"],
         "//conditions:default": [],
     }),
     visibility = ["//visibility:public"],
@@ -446,8 +474,8 @@ boost_library(
     ],
     defines = [
         "BOOST_ASIO_SEPARATE_COMPILATION",
-    ] + select({
-        ":osx": [
+    ] + selects.with_or({
+        (":osx", ":ios", ":watchos", ":tvos"): [
             "BOOST_ASIO_DISABLE_STD_EXPERIMENTAL_STRING_VIEW",
         ],
         "//conditions:default": [],
@@ -601,9 +629,11 @@ boost_library(
 
 boost_library(
     name = "compute",
-    linkopts = select({
-        ":osx": [
-            "-framework OpenCL",
+    linkopts = selects.with_or({
+        # OpenCL (required for Boost.Compute) is deprecated on macOS and not supported on other Apple OSs.
+        # This will at least produce the right error message, indicating that OpenCL is not present
+        (":osx", ":ios", ":watchos", ":tvos"): [
+            "-framework OpenCL", 
         ],
         "//conditions:default": [
             "-lOpenCL",
@@ -702,14 +732,8 @@ boost_library(
     ],
 )
 
-BOOST_CORO_SRCS = select({
-    ":android": [
-        "libs/coroutine/src/posix/stack_traits.cpp",
-    ],
-    ":linux": [
-        "libs/coroutine/src/posix/stack_traits.cpp",
-    ],
-    ":osx": [
+BOOST_CORO_SRCS = selects.with_or({
+    (":linux", ":android", ":osx", ":ios", ":watchos", ":tvos"): [
         "libs/coroutine/src/posix/stack_traits.cpp",
     ],
     ":windows_x86_64": [
@@ -1218,22 +1242,14 @@ BOOST_LOCALE_WIN32_COPTS = [
 
 boost_library(
     name = "locale",
-    srcs = select({
+    srcs = selects.with_or({
         ":android": BOOST_LOCALE_STD_SOURCES,
-        ":linux_arm": BOOST_LOCALE_POSIX_SOURCES,
-        ":linux_aarch64": BOOST_LOCALE_POSIX_SOURCES,
-        ":linux_ppc": BOOST_LOCALE_POSIX_SOURCES,
-        ":linux_x86_64": BOOST_LOCALE_POSIX_SOURCES,
-        ":osx": BOOST_LOCALE_POSIX_SOURCES,
+        (":linux", ":osx", ":ios", ":watchos", ":tvos"): BOOST_LOCALE_POSIX_SOURCES,
         ":windows_x86_64": BOOST_LOCALE_WIN32_SOURCES,
     }),
-    copts = select({
+    copts = selects.with_or({
         ":android": BOST_LOCALE_STD_COPTS,
-        ":linux_arm": BOOST_LOCALE_POSIX_COPTS,
-        ":linux_aarch64": BOOST_LOCALE_POSIX_COPTS,
-        ":linux_ppc": BOOST_LOCALE_POSIX_COPTS,
-        ":linux_x86_64": BOOST_LOCALE_POSIX_COPTS,
-        ":osx": BOOST_LOCALE_POSIX_COPTS,
+        (":linux", ":osx", ":ios", ":watchos", ":tvos"): BOOST_LOCALE_POSIX_COPTS,
         ":windows_x86_64": BOOST_LOCALE_WIN32_COPTS,
     }) + _w_no_deprecated,
     deps = [
@@ -1864,7 +1880,7 @@ boost_library(
     ],
 )
 
-BOOST_STACKTRACE_SOURCES = select({
+BOOST_STACKTRACE_SOURCES = selects.with_or({
     ":android": [
         "libs/stacktrace/src/basic.cpp",
         #"libs/stacktrace/src/noop.cpp",
@@ -1883,7 +1899,7 @@ BOOST_STACKTRACE_SOURCES = select({
     ":linux_x86_64": [
         "libs/stacktrace/src/backtrace.cpp",
     ],
-    ":osx": [
+    (":osx", ":ios", ":watchos", ":tvos"): [
         "libs/stacktrace/src/addr2line.cpp",
     ],
     ":windows_x86_64": [
@@ -1896,8 +1912,8 @@ BOOST_STACKTRACE_SOURCES = select({
 boost_library(
     name = "stacktrace",
     srcs = BOOST_STACKTRACE_SOURCES,
-    defines = select({
-        ":osx": [
+    defines = selects.with_or({
+        (":osx", ":ios", ":watchos", ":tvos"): [
             "BOOST_STACKTRACE_GNU_SOURCE_NOT_REQUIRED",
         ],
         "//conditions:default": [],
@@ -1988,11 +2004,7 @@ boost_library(
 boost_library(
     name = "thread",
     srcs = selects.with_or({
-        (":linux", ":android"): [
-            "libs/thread/src/pthread/once.cpp",
-            "libs/thread/src/pthread/thread.cpp",
-        ],
-        ":osx": [
+        (":linux", ":android", ":osx", ":ios", ":watchos", ":tvos"): [
             "libs/thread/src/pthread/once.cpp",
             "libs/thread/src/pthread/thread.cpp",
         ],
@@ -2003,29 +2015,18 @@ boost_library(
         ],
     }),
     hdrs = selects.with_or({
-        (":linux", ":android"): [
-            "libs/thread/src/pthread/once_atomic.cpp",
-        ],
-        ":osx": [
+        (":linux", ":android", ":osx", ":ios", ":watchos", ":tvos"): [
             "libs/thread/src/pthread/once_atomic.cpp",
         ],
         ":windows_x86_64": [],
     }),
-    linkopts = select({
-        ":linux": [
-            "-lpthread",
-        ],
-        ":osx": [
-            "-lpthread",
-        ],
+    linkopts = selects.with_or({
+        (":linux", ":osx", ":ios", ":watchos", ":tvos"): ["-lpthread"],
         ":windows_x86_64": [],
         ":android": [],
     }),
-    local_defines = select({
-        ":linux_arm": [],
-        ":linux_ppc": [],
-        ":linux_x86_64": [],
-        ":osx": [],
+    local_defines = selects.with_or({
+        (":linux", ":osx", ":ios", ":watchos", ":tvos"): [],
         ":windows_x86_64": [
             "BOOST_ALL_NO_LIB",
             "BOOST_THREAD_BUILD_LIB",

--- a/BUILD.boost
+++ b/BUILD.boost
@@ -13,7 +13,7 @@ _w_no_deprecated = selects.with_or({
 config_setting(
     name = "linux",
     constraint_values = [
-        "@bazel_tools//platforms:linux",
+        "@platforms//os:linux",
     ],
     visibility = ["//visibility:public"],
 )
@@ -21,7 +21,7 @@ config_setting(
 config_setting(
     name = "android",
     constraint_values = [
-        "@bazel_tools//platforms:android",
+        "@platforms//os:android",
     ],
     visibility = ["//visibility:public"],
 )
@@ -29,7 +29,7 @@ config_setting(
 config_setting(
     name = "osx",
     constraint_values = [
-        "@bazel_tools//platforms:osx",
+        "@platforms//os:osx",
     ],
     visibility = ["//visibility:public"],
 )
@@ -37,7 +37,7 @@ config_setting(
 config_setting(
     name = "ios",
     constraint_values = [
-        "@bazel_tools//platforms:ios",
+        "@platforms//os:ios",
     ],
     visibility = ["//visibility:public"],
 )
@@ -61,7 +61,7 @@ config_setting(
 config_setting(
     name = "windows",
     constraint_values = [
-        "@bazel_tools//platforms:windows",
+        "@platforms//os:windows",
     ],
     visibility = ["//visibility:public"],
 )
@@ -69,8 +69,8 @@ config_setting(
 config_setting(
     name = "linux_arm",
     constraint_values = [
-        "@bazel_tools//platforms:linux",
-        "@bazel_tools//platforms:arm",
+        "@platforms//os:linux",
+        "@platforms//cpu:arm",
     ],
     visibility = ["//visibility:public"],
 )
@@ -78,8 +78,8 @@ config_setting(
 config_setting(
     name = "linux_ppc",
     constraint_values = [
-        "@bazel_tools//platforms:linux",
-        "@bazel_tools//platforms:ppc",
+        "@platforms//os:linux",
+        "@platforms//cpu:ppc",
     ],
     visibility = ["//visibility:public"],
 )
@@ -87,8 +87,8 @@ config_setting(
 config_setting(
     name = "linux_aarch64",
     constraint_values = [
-        "@bazel_tools//platforms:linux",
-        "@bazel_tools//platforms:aarch64",
+        "@platforms//os:linux",
+        "@platforms//cpu:aarch64",
     ],
     visibility = ["//visibility:public"],
 )
@@ -96,8 +96,8 @@ config_setting(
 config_setting(
     name = "linux_x86_64",
     constraint_values = [
-        "@bazel_tools//platforms:linux",
-        "@bazel_tools//platforms:x86_64",
+        "@platforms//os:linux",
+        "@platforms//cpu:x86_64",
     ],
     visibility = ["//visibility:public"],
 )
@@ -105,8 +105,8 @@ config_setting(
 config_setting(
     name = "osx_arm64",
     constraint_values = [
-        "@bazel_tools//platforms:osx",
-        "@bazel_tools//platforms:aarch64",
+        "@platforms//os:osx",
+        "@platforms//cpu:aarch64",
     ],
     visibility = ["//visibility:public"],
 )
@@ -114,8 +114,8 @@ config_setting(
 config_setting(
     name = "osx_x86_64",
     constraint_values = [
-        "@bazel_tools//platforms:osx",
-        "@bazel_tools//platforms:x86_64",
+        "@platforms//os:osx",
+        "@platforms//cpu:x86_64",
     ],
     visibility = ["//visibility:public"],
 )
@@ -123,8 +123,8 @@ config_setting(
 config_setting(
     name = "windows_x86_64",
     constraint_values = [
-        "@bazel_tools//platforms:windows",
-        "@bazel_tools//platforms:x86_64",
+        "@platforms//os:windows",
+        "@platforms//cpu:x86_64",
     ],
     visibility = ["//visibility:public"],
 )
@@ -132,7 +132,7 @@ config_setting(
 config_setting(
     name = "x86_64",
     constraint_values = [
-        "@bazel_tools//platforms:x86_64",
+        "@platforms//cpu:x86_64",
     ],
     visibility = ["//visibility:public"],
 )
@@ -140,8 +140,8 @@ config_setting(
 config_setting(
     name = "android_arm",
     constraint_values = [
-        "@bazel_tools//platforms:android",
-        "@bazel_tools//platforms:arm",
+        "@platforms//os:android",
+        "@platforms//cpu:arm",
     ],
     visibility = ["//visibility:public"],
 )
@@ -149,8 +149,8 @@ config_setting(
 config_setting(
     name = "android_aarch64",
     constraint_values = [
-        "@bazel_tools//platforms:android",
-        "@bazel_tools//platforms:aarch64",
+        "@platforms//os:android",
+        "@platforms//cpu:aarch64",
     ],
     visibility = ["//visibility:public"],
 )
@@ -199,17 +199,17 @@ BOOST_CTX_ASM_SOURCES = selects.with_or({
 filegroup(
     name = "apple_ctx_asm_sources",
     srcs = select({
-        "@bazel_tools//platforms:aarch64": [
+        "@platforms//cpu:aarch64": [
             "libs/context/src/asm/jump_arm64_aapcs_macho_gas.S",
             "libs/context/src/asm/make_arm64_aapcs_macho_gas.S",
             "libs/context/src/asm/ontop_arm64_aapcs_macho_gas.S",
         ],
-        "@bazel_tools//platforms:arm": [
+        "@platforms//cpu:arm": [
             "libs/context/src/asm/jump_arm_aapcs_macho_gas.S",
             "libs/context/src/asm/make_arm_aapcs_macho_gas.S",
             "libs/context/src/asm/ontop_arm_aapcs_macho_gas.S",
         ],
-        "@bazel_tools//platforms:x86_64": [
+        "@platforms//cpu:x86_64": [
             "libs/context/src/asm/jump_x86_64_sysv_macho_gas.S",
             "libs/context/src/asm/make_x86_64_sysv_macho_gas.S",
             "libs/context/src/asm/ontop_x86_64_sysv_macho_gas.S",

--- a/BUILD.lzma
+++ b/BUILD.lzma
@@ -3,6 +3,7 @@
 #    Public Domain
 
 load("@bazel_skylib//rules:copy_file.bzl", "copy_file")
+load("@bazel_skylib//lib:selects.bzl", "selects")
 
 config_setting(
     name = "linux",
@@ -26,6 +27,29 @@ config_setting(
 )
 
 config_setting(
+    name = "ios",
+    constraint_values = [
+        "@bazel_tools//platforms:ios",
+    ],
+)
+
+config_setting(
+    name = "watchos",
+    constraint_values = [
+        "@platforms//os:watchos",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
+    name = "tvos",
+    constraint_values = [
+        "@platforms//os:tvos",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
     name = "windows",
     constraint_values = ["@bazel_tools//platforms:windows"],
 )
@@ -35,16 +59,48 @@ config_setting(
     constraint_values = ["@bazel_tools//platforms:android"],
 )
 
+config_setting(
+    name = "arm",
+    constraint_values = ["@bazel_tools//platforms:arm"],
+)
+
+config_setting(
+    name = "aarch64",
+    constraint_values = ["@bazel_tools//platforms:aarch64"],
+)
+
+config_setting(
+    name = "x86_64",
+    constraint_values = ["@bazel_tools//platforms:x86_64"],
+)
+
+config_setting(
+    name = "x86_32",
+    constraint_values = ["@bazel_tools//platforms:x86_32"],
+)
+
 copy_file(
     name = "copy_config",
-    src = select({
+    src = selects.with_or({
         ":android": "@com_github_nelhage_rules_boost//:config.lzma-android.h",
         ":linux": "@com_github_nelhage_rules_boost//:config.lzma-linux.h",
         ":osx_arm64": "@com_github_nelhage_rules_boost//:config.lzma-osx-arm64.h",
         ":osx_x86_64": "@com_github_nelhage_rules_boost//:config.lzma-osx-x86_64.h",
+        (":ios", ":watchos", ":tvos"): "apple_config",
         ":windows": "@com_github_nelhage_rules_boost//:config.lzma-windows.h",
     }),
     out = "src/liblzma/api/config.h", # minimize the number of exported include paths
+)
+
+# Configuration is the same across iOS, watchOS, and tvOS
+alias(
+    name = "apple_config",
+    actual = select({
+        ":aarch64": "config.lzma-ios-arm64.h",
+        ":arm": "config.lzma-ios-armv7.h",
+        ":x86_64": "config.lzma-osx-x86_64.h", # Configuration same as macOS
+        ":x86_32": "config.lzma-ios-i386.h",
+    }),
 )
 
 cc_library(

--- a/BUILD.lzma
+++ b/BUILD.lzma
@@ -7,29 +7,29 @@ load("@bazel_skylib//lib:selects.bzl", "selects")
 
 config_setting(
     name = "linux",
-    constraint_values = ["@bazel_tools//platforms:linux"],
+    constraint_values = ["@platforms//os:linux"],
 )
 
 config_setting(
     name = "osx_arm64",
     constraint_values = [
-        "@bazel_tools//platforms:osx",
-        "@bazel_tools//platforms:aarch64",
+        "@platforms//os:osx",
+        "@platforms//cpu:aarch64",
     ],
 )
 
 config_setting(
     name = "osx_x86_64",
     constraint_values = [
-        "@bazel_tools//platforms:osx",
-        "@bazel_tools//platforms:x86_64",
+        "@platforms//os:osx",
+        "@platforms//cpu:x86_64",
     ],
 )
 
 config_setting(
     name = "ios",
     constraint_values = [
-        "@bazel_tools//platforms:ios",
+        "@platforms//os:ios",
     ],
 )
 
@@ -51,32 +51,32 @@ config_setting(
 
 config_setting(
     name = "windows",
-    constraint_values = ["@bazel_tools//platforms:windows"],
+    constraint_values = ["@platforms//os:windows"],
 )
 
 config_setting(
     name = "android",
-    constraint_values = ["@bazel_tools//platforms:android"],
+    constraint_values = ["@platforms//os:android"],
 )
 
 config_setting(
     name = "arm",
-    constraint_values = ["@bazel_tools//platforms:arm"],
+    constraint_values = ["@platforms//cpu:arm"],
 )
 
 config_setting(
     name = "aarch64",
-    constraint_values = ["@bazel_tools//platforms:aarch64"],
+    constraint_values = ["@platforms//cpu:aarch64"],
 )
 
 config_setting(
     name = "x86_64",
-    constraint_values = ["@bazel_tools//platforms:x86_64"],
+    constraint_values = ["@platforms//cpu:x86_64"],
 )
 
 config_setting(
     name = "x86_32",
-    constraint_values = ["@bazel_tools//platforms:x86_32"],
+    constraint_values = ["@platforms//cpu:x86_32"],
 )
 
 copy_file(

--- a/BUILD.zlib
+++ b/BUILD.zlib
@@ -1,9 +1,50 @@
-package(default_visibility = ["//visibility:public"])
+load("@bazel_skylib//lib:selects.bzl", "selects")
 
 licenses(["notice"])  # BSD/MIT-like license (for zlib)
 
-cc_library(
+alias(
     name = "zlib",
+    visibility = ["//visibility:public"],
+    actual = selects.with_or({
+        (":android", ":ios", ":watchos", ":tvos"): ":zlib_system",
+        "//conditions:default": ":zlib_source",
+    })
+)
+
+config_setting(
+    name = "android",
+    constraint_values = [
+        "@bazel_tools//platforms:android",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
+    name = "ios",
+    constraint_values = [
+        "@bazel_tools//platforms:ios",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
+    name = "watchos",
+    constraint_values = [
+        "@platforms//os:watchos",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
+    name = "tvos",
+    constraint_values = [
+        "@platforms//os:tvos",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "zlib_source",
     srcs = [
         "adler32.c",
         "compress.c",
@@ -41,4 +82,10 @@ cc_library(
         "@boost//:windows": [],
         "//conditions:default": ["Z_HAVE_UNISTD_H"],
     }),
+)
+
+# For OSs that bundle libz
+cc_library( 
+    name = "zlib_system",
+    linkopts = ["-lz"],
 )

--- a/BUILD.zlib
+++ b/BUILD.zlib
@@ -14,7 +14,7 @@ alias(
 config_setting(
     name = "android",
     constraint_values = [
-        "@bazel_tools//platforms:android",
+        "@platforms//os:android",
     ],
     visibility = ["//visibility:public"],
 )
@@ -22,7 +22,7 @@ config_setting(
 config_setting(
     name = "ios",
     constraint_values = [
-        "@bazel_tools//platforms:ios",
+        "@platforms//os:ios",
     ],
     visibility = ["//visibility:public"],
 )

--- a/BUILD.zstd
+++ b/BUILD.zstd
@@ -37,7 +37,7 @@ cc_library(
 config_setting(
     name = "linux_x86_64",
     constraint_values = [
-        "@bazel_tools//platforms:linux",
-        "@bazel_tools//platforms:x86_64",
+        "@platforms//os:linux",
+        "@platforms//cpu:x86_64",
     ],
 )

--- a/config.lzma-ios-arm64.h
+++ b/config.lzma-ios-arm64.h
@@ -1,0 +1,502 @@
+/* config.h.  Generated from config.h.in by configure.  */
+/* config.h.in.  Generated from configure.ac by autoheader.  */
+
+/* Define if building universal (internal helper macro) */
+/* #undef AC_APPLE_UNIVERSAL_BUILD */
+
+/* How many MiB of RAM to assume if the real amount cannot be determined. */
+#define ASSUME_RAM 128
+
+/* Define to 1 if translation of program messages to the user's native
+   language is requested. */
+/* #undef ENABLE_NLS */
+
+/* Define to 1 if bswap_16 is available. */
+/* #undef HAVE_BSWAP_16 */
+
+/* Define to 1 if bswap_32 is available. */
+/* #undef HAVE_BSWAP_32 */
+
+/* Define to 1 if bswap_64 is available. */
+/* #undef HAVE_BSWAP_64 */
+
+/* Define to 1 if you have the <byteswap.h> header file. */
+/* #undef HAVE_BYTESWAP_H */
+
+/* Define to 1 if Capsicum is available. */
+/* #undef HAVE_CAPSICUM */
+
+/* Define to 1 if the system has the type `CC_SHA256_CTX'. */
+/* #undef HAVE_CC_SHA256_CTX */
+
+/* Define to 1 if you have the `CC_SHA256_Init' function. */
+/* #undef HAVE_CC_SHA256_INIT */
+
+/* Define to 1 if you have the Mac OS X function CFLocaleCopyCurrent in the
+   CoreFoundation framework. */
+#define HAVE_CFLOCALECOPYCURRENT 1
+
+/* Define to 1 if you have the Mac OS X function CFPreferencesCopyAppValue in
+   the CoreFoundation framework. */
+#define HAVE_CFPREFERENCESCOPYAPPVALUE 1
+
+/* Define to 1 if crc32 integrity check is enabled. */
+#define HAVE_CHECK_CRC32 1
+
+/* Define to 1 if crc64 integrity check is enabled. */
+#define HAVE_CHECK_CRC64 1
+
+/* Define to 1 if sha256 integrity check is enabled. */
+#define HAVE_CHECK_SHA256 1
+
+/* Define to 1 if you have the `clock_gettime' function. */
+#define HAVE_CLOCK_GETTIME 1
+
+/* Define to 1 if you have the <CommonCrypto/CommonDigest.h> header file. */
+/* #undef HAVE_COMMONCRYPTO_COMMONDIGEST_H */
+
+/* Define if the GNU dcgettext() function is already present or preinstalled.
+   */
+/* #undef HAVE_DCGETTEXT */
+
+/* Define to 1 if you have the declaration of `CLOCK_MONOTONIC', and to 0 if
+   you don't. */
+#define HAVE_DECL_CLOCK_MONOTONIC 1
+
+/* Define to 1 if you have the declaration of `program_invocation_name', and
+   to 0 if you don't. */
+#define HAVE_DECL_PROGRAM_INVOCATION_NAME 0
+
+/* Define to 1 if any of HAVE_DECODER_foo have been defined. */
+#define HAVE_DECODERS 1
+
+/* Define to 1 if arm decoder is enabled. */
+#define HAVE_DECODER_ARM 1
+
+/* Define to 1 if armthumb decoder is enabled. */
+#define HAVE_DECODER_ARMTHUMB 1
+
+/* Define to 1 if delta decoder is enabled. */
+#define HAVE_DECODER_DELTA 1
+
+/* Define to 1 if ia64 decoder is enabled. */
+#define HAVE_DECODER_IA64 1
+
+/* Define to 1 if lzma1 decoder is enabled. */
+#define HAVE_DECODER_LZMA1 1
+
+/* Define to 1 if lzma2 decoder is enabled. */
+#define HAVE_DECODER_LZMA2 1
+
+/* Define to 1 if powerpc decoder is enabled. */
+#define HAVE_DECODER_POWERPC 1
+
+/* Define to 1 if sparc decoder is enabled. */
+#define HAVE_DECODER_SPARC 1
+
+/* Define to 1 if x86 decoder is enabled. */
+#define HAVE_DECODER_X86 1
+
+/* Define to 1 if you have the <dlfcn.h> header file. */
+#define HAVE_DLFCN_H 1
+
+/* Define to 1 if any of HAVE_ENCODER_foo have been defined. */
+#define HAVE_ENCODERS 1
+
+/* Define to 1 if arm encoder is enabled. */
+#define HAVE_ENCODER_ARM 1
+
+/* Define to 1 if armthumb encoder is enabled. */
+#define HAVE_ENCODER_ARMTHUMB 1
+
+/* Define to 1 if delta encoder is enabled. */
+#define HAVE_ENCODER_DELTA 1
+
+/* Define to 1 if ia64 encoder is enabled. */
+#define HAVE_ENCODER_IA64 1
+
+/* Define to 1 if lzma1 encoder is enabled. */
+#define HAVE_ENCODER_LZMA1 1
+
+/* Define to 1 if lzma2 encoder is enabled. */
+#define HAVE_ENCODER_LZMA2 1
+
+/* Define to 1 if powerpc encoder is enabled. */
+#define HAVE_ENCODER_POWERPC 1
+
+/* Define to 1 if sparc encoder is enabled. */
+#define HAVE_ENCODER_SPARC 1
+
+/* Define to 1 if x86 encoder is enabled. */
+#define HAVE_ENCODER_X86 1
+
+/* Define to 1 if you have the <fcntl.h> header file. */
+#define HAVE_FCNTL_H 1
+
+/* Define to 1 if you have the `futimens' function. */
+#define HAVE_FUTIMENS 1
+
+/* Define to 1 if you have the `futimes' function. */
+/* #undef HAVE_FUTIMES */
+
+/* Define to 1 if you have the `futimesat' function. */
+/* #undef HAVE_FUTIMESAT */
+
+/* Define to 1 if you have the <getopt.h> header file. */
+#define HAVE_GETOPT_H 1
+
+/* Define to 1 if you have the `getopt_long' function. */
+#define HAVE_GETOPT_LONG 1
+
+/* Define if the GNU gettext() function is already present or preinstalled. */
+/* #undef HAVE_GETTEXT */
+
+/* Define if you have the iconv() function and it works. */
+#define HAVE_ICONV 1
+
+/* Define to 1 if you have the <immintrin.h> header file. */
+/* #undef HAVE_IMMINTRIN_H */
+
+/* Define to 1 if you have the <inttypes.h> header file. */
+#define HAVE_INTTYPES_H 1
+
+/* Define to 1 if you have the <limits.h> header file. */
+#define HAVE_LIMITS_H 1
+
+/* Define to 1 if mbrtowc and mbstate_t are properly declared. */
+#define HAVE_MBRTOWC 1
+
+/* Define to 1 if you have the <memory.h> header file. */
+#define HAVE_MEMORY_H 1
+
+/* Define to 1 to enable bt2 match finder. */
+#define HAVE_MF_BT2 1
+
+/* Define to 1 to enable bt3 match finder. */
+#define HAVE_MF_BT3 1
+
+/* Define to 1 to enable bt4 match finder. */
+#define HAVE_MF_BT4 1
+
+/* Define to 1 to enable hc3 match finder. */
+#define HAVE_MF_HC3 1
+
+/* Define to 1 to enable hc4 match finder. */
+#define HAVE_MF_HC4 1
+
+/* Define to 1 if getopt.h declares extern int optreset. */
+#define HAVE_OPTRESET 1
+
+/* Define to 1 if you have the `posix_fadvise' function. */
+/* #undef HAVE_POSIX_FADVISE */
+
+/* Define to 1 if you have the `pthread_condattr_setclock' function. */
+/* #undef HAVE_PTHREAD_CONDATTR_SETCLOCK */
+
+/* Have PTHREAD_PRIO_INHERIT. */
+#define HAVE_PTHREAD_PRIO_INHERIT 1
+
+/* Define to 1 if you have the `SHA256Init' function. */
+/* #undef HAVE_SHA256INIT */
+
+/* Define to 1 if the system has the type `SHA256_CTX'. */
+/* #undef HAVE_SHA256_CTX */
+
+/* Define to 1 if you have the <sha256.h> header file. */
+/* #undef HAVE_SHA256_H */
+
+/* Define to 1 if you have the `SHA256_Init' function. */
+/* #undef HAVE_SHA256_INIT */
+
+/* Define to 1 if the system has the type `SHA2_CTX'. */
+/* #undef HAVE_SHA2_CTX */
+
+/* Define to 1 if you have the <sha2.h> header file. */
+/* #undef HAVE_SHA2_H */
+
+/* Define to 1 if optimizing for size. */
+/* #undef HAVE_SMALL */
+
+/* Define to 1 if stdbool.h conforms to C99. */
+#define HAVE_STDBOOL_H 1
+
+/* Define to 1 if you have the <stdint.h> header file. */
+#define HAVE_STDINT_H 1
+
+/* Define to 1 if you have the <stdlib.h> header file. */
+#define HAVE_STDLIB_H 1
+
+/* Define to 1 if you have the <strings.h> header file. */
+#define HAVE_STRINGS_H 1
+
+/* Define to 1 if you have the <string.h> header file. */
+#define HAVE_STRING_H 1
+
+/* Define to 1 if `st_atimensec' is a member of `struct stat'. */
+/* #undef HAVE_STRUCT_STAT_ST_ATIMENSEC */
+
+/* Define to 1 if `st_atimespec.tv_nsec' is a member of `struct stat'. */
+#define HAVE_STRUCT_STAT_ST_ATIMESPEC_TV_NSEC 1
+
+/* Define to 1 if `st_atim.st__tim.tv_nsec' is a member of `struct stat'. */
+/* #undef HAVE_STRUCT_STAT_ST_ATIM_ST__TIM_TV_NSEC */
+
+/* Define to 1 if `st_atim.tv_nsec' is a member of `struct stat'. */
+/* #undef HAVE_STRUCT_STAT_ST_ATIM_TV_NSEC */
+
+/* Define to 1 if `st_uatime' is a member of `struct stat'. */
+/* #undef HAVE_STRUCT_STAT_ST_UATIME */
+
+/* Define to 1 if you have the <sys/byteorder.h> header file. */
+/* #undef HAVE_SYS_BYTEORDER_H */
+
+/* Define to 1 if you have the <sys/capsicum.h> header file. */
+/* #undef HAVE_SYS_CAPSICUM_H */
+
+/* Define to 1 if you have the <sys/endian.h> header file. */
+/* #undef HAVE_SYS_ENDIAN_H */
+
+/* Define to 1 if you have the <sys/param.h> header file. */
+#define HAVE_SYS_PARAM_H 1
+
+/* Define to 1 if you have the <sys/stat.h> header file. */
+#define HAVE_SYS_STAT_H 1
+
+/* Define to 1 if you have the <sys/time.h> header file. */
+#define HAVE_SYS_TIME_H 1
+
+/* Define to 1 if you have the <sys/types.h> header file. */
+#define HAVE_SYS_TYPES_H 1
+
+/* Define to 1 if the system has the type `uintptr_t'. */
+#define HAVE_UINTPTR_T 1
+
+/* Define to 1 if you have the <unistd.h> header file. */
+#define HAVE_UNISTD_H 1
+
+/* Define to 1 if you have the `utime' function. */
+/* #undef HAVE_UTIME */
+
+/* Define to 1 if you have the `utimes' function. */
+/* #undef HAVE_UTIMES */
+
+/* Define to 1 or 0, depending whether the compiler supports simple visibility
+   declarations. */
+#define HAVE_VISIBILITY 1
+
+/* Define to 1 if you have the `wcwidth' function. */
+#define HAVE_WCWIDTH 1
+
+/* Define to 1 if the system has the type `_Bool'. */
+#define HAVE__BOOL 1
+
+/* Define to 1 if you have the `_futime' function. */
+/* #undef HAVE__FUTIME */
+
+/* Define to 1 if _mm_movemask_epi8 is available. */
+/* #undef HAVE__MM_MOVEMASK_EPI8 */
+
+/* Define to the sub-directory where libtool stores uninstalled libraries. */
+#define LT_OBJDIR ".libs/"
+
+/* Define to 1 when using POSIX threads (pthreads). */
+#define MYTHREAD_POSIX 1
+
+/* Define to 1 when using Windows Vista compatible threads. This uses features
+   that are not available on Windows XP. */
+/* #undef MYTHREAD_VISTA */
+
+/* Define to 1 when using Windows 95 (and thus XP) compatible threads. This
+   avoids use of features that were added in Windows Vista. */
+/* #undef MYTHREAD_WIN95 */
+
+/* Define to 1 to disable debugging code. */
+#define NDEBUG 1
+
+/* Name of package */
+#define PACKAGE "xz"
+
+/* Define to the address where bug reports for this package should be sent. */
+#define PACKAGE_BUGREPORT "lasse.collin@tukaani.org"
+
+/* Define to the full name of this package. */
+#define PACKAGE_NAME "XZ Utils"
+
+/* Define to the full name and version of this package. */
+#define PACKAGE_STRING "XZ Utils 5.2.3"
+
+/* Define to the one symbol short name of this package. */
+#define PACKAGE_TARNAME "xz"
+
+/* Define to the home page for this package. */
+#define PACKAGE_URL "http://tukaani.org/xz/"
+
+/* Define to the version of this package. */
+#define PACKAGE_VERSION "5.2.3"
+
+/* Define to necessary symbol if this constant uses a non-standard name on
+   your system. */
+/* #undef PTHREAD_CREATE_JOINABLE */
+
+/* The size of `size_t', as computed by sizeof. */
+#define SIZEOF_SIZE_T 8
+
+/* Define to 1 if you have the ANSI C header files. */
+#define STDC_HEADERS 1
+
+/* Define to 1 if the number of available CPU cores can be detected with
+   cpuset(2). */
+/* #undef TUKLIB_CPUCORES_CPUSET */
+
+/* Define to 1 if the number of available CPU cores can be detected with
+   pstat_getdynamic(). */
+/* #undef TUKLIB_CPUCORES_PSTAT_GETDYNAMIC */
+
+/* Define to 1 if the number of available CPU cores can be detected with
+   sched_getaffinity() */
+/* #undef TUKLIB_CPUCORES_SCHED_GETAFFINITY */
+
+/* Define to 1 if the number of available CPU cores can be detected with
+   sysconf(_SC_NPROCESSORS_ONLN) or sysconf(_SC_NPROC_ONLN). */
+/* #undef TUKLIB_CPUCORES_SYSCONF */
+
+/* Define to 1 if the number of available CPU cores can be detected with
+   sysctl(). */
+#define TUKLIB_CPUCORES_SYSCTL 1
+
+/* Define to 1 if the system supports fast unaligned access to 16-bit and
+   32-bit integers. */
+#define TUKLIB_FAST_UNALIGNED_ACCESS 1
+
+/* Define to 1 if the amount of physical memory can be detected with
+   _system_configuration.physmem. */
+/* #undef TUKLIB_PHYSMEM_AIX */
+
+/* Define to 1 if the amount of physical memory can be detected with
+   getinvent_r(). */
+/* #undef TUKLIB_PHYSMEM_GETINVENT_R */
+
+/* Define to 1 if the amount of physical memory can be detected with
+   getsysinfo(). */
+/* #undef TUKLIB_PHYSMEM_GETSYSINFO */
+
+/* Define to 1 if the amount of physical memory can be detected with
+   pstat_getstatic(). */
+/* #undef TUKLIB_PHYSMEM_PSTAT_GETSTATIC */
+
+/* Define to 1 if the amount of physical memory can be detected with
+   sysconf(_SC_PAGESIZE) and sysconf(_SC_PHYS_PAGES). */
+#define TUKLIB_PHYSMEM_SYSCONF 1
+
+/* Define to 1 if the amount of physical memory can be detected with sysctl().
+   */
+/* #undef TUKLIB_PHYSMEM_SYSCTL */
+
+/* Define to 1 if the amount of physical memory can be detected with Linux
+   sysinfo(). */
+/* #undef TUKLIB_PHYSMEM_SYSINFO */
+
+/* Enable extensions on AIX 3, Interix.  */
+#ifndef _ALL_SOURCE
+# define _ALL_SOURCE 1
+#endif
+/* Enable GNU extensions on systems that have them.  */
+#ifndef _GNU_SOURCE
+# define _GNU_SOURCE 1
+#endif
+/* Enable threading extensions on Solaris.  */
+#ifndef _POSIX_PTHREAD_SEMANTICS
+# define _POSIX_PTHREAD_SEMANTICS 1
+#endif
+/* Enable extensions on HP NonStop.  */
+#ifndef _TANDEM_SOURCE
+# define _TANDEM_SOURCE 1
+#endif
+/* Enable general extensions on Solaris.  */
+#ifndef __EXTENSIONS__
+# define __EXTENSIONS__ 1
+#endif
+
+
+/* Version number of package */
+#define VERSION "5.2.3"
+
+/* Define WORDS_BIGENDIAN to 1 if your processor stores words with the most
+   significant byte first (like Motorola and SPARC, unlike Intel). */
+#if defined AC_APPLE_UNIVERSAL_BUILD
+# if defined __BIG_ENDIAN__
+#  define WORDS_BIGENDIAN 1
+# endif
+#else
+# ifndef WORDS_BIGENDIAN
+/* #  undef WORDS_BIGENDIAN */
+# endif
+#endif
+
+/* Enable large inode numbers on Mac OS X 10.5.  */
+#ifndef _DARWIN_USE_64_BIT_INODE
+# define _DARWIN_USE_64_BIT_INODE 1
+#endif
+
+/* Number of bits in a file offset, on hosts where this is settable. */
+/* #undef _FILE_OFFSET_BITS */
+
+/* Define for large files, on AIX-style hosts. */
+/* #undef _LARGE_FILES */
+
+/* Define to 1 if on MINIX. */
+/* #undef _MINIX */
+
+/* Define to 2 if the system does not provide POSIX.1 features except with
+   this defined. */
+/* #undef _POSIX_1_SOURCE */
+
+/* Define to 1 if you need to in order for `stat' and other things to work. */
+/* #undef _POSIX_SOURCE */
+
+/* Define for Solaris 2.5.1 so the uint32_t typedef from <sys/synch.h>,
+   <pthread.h>, or <semaphore.h> is not used. If the typedef were allowed, the
+   #define below would cause a syntax error. */
+/* #undef _UINT32_T */
+
+/* Define for Solaris 2.5.1 so the uint64_t typedef from <sys/synch.h>,
+   <pthread.h>, or <semaphore.h> is not used. If the typedef were allowed, the
+   #define below would cause a syntax error. */
+/* #undef _UINT64_T */
+
+/* Define for Solaris 2.5.1 so the uint8_t typedef from <sys/synch.h>,
+   <pthread.h>, or <semaphore.h> is not used. If the typedef were allowed, the
+   #define below would cause a syntax error. */
+/* #undef _UINT8_T */
+
+/* Define to rpl_ if the getopt replacement functions and variables should be
+   used. */
+/* #undef __GETOPT_PREFIX */
+
+/* Define to the type of a signed integer type of width exactly 32 bits if
+   such a type exists and the standard includes do not define it. */
+/* #undef int32_t */
+
+/* Define to the type of a signed integer type of width exactly 64 bits if
+   such a type exists and the standard includes do not define it. */
+/* #undef int64_t */
+
+/* Define to the type of an unsigned integer type of width exactly 16 bits if
+   such a type exists and the standard includes do not define it. */
+/* #undef uint16_t */
+
+/* Define to the type of an unsigned integer type of width exactly 32 bits if
+   such a type exists and the standard includes do not define it. */
+/* #undef uint32_t */
+
+/* Define to the type of an unsigned integer type of width exactly 64 bits if
+   such a type exists and the standard includes do not define it. */
+/* #undef uint64_t */
+
+/* Define to the type of an unsigned integer type of width exactly 8 bits if
+   such a type exists and the standard includes do not define it. */
+/* #undef uint8_t */
+
+/* Define to the type of an unsigned integer type wide enough to hold a
+   pointer, if such a type exists, and if the system does not define it. */
+/* #undef uintptr_t */

--- a/config.lzma-ios-armv7.h
+++ b/config.lzma-ios-armv7.h
@@ -1,0 +1,502 @@
+/* config.h.  Generated from config.h.in by configure.  */
+/* config.h.in.  Generated from configure.ac by autoheader.  */
+
+/* Define if building universal (internal helper macro) */
+/* #undef AC_APPLE_UNIVERSAL_BUILD */
+
+/* How many MiB of RAM to assume if the real amount cannot be determined. */
+#define ASSUME_RAM 128
+
+/* Define to 1 if translation of program messages to the user's native
+   language is requested. */
+/* #undef ENABLE_NLS */
+
+/* Define to 1 if bswap_16 is available. */
+/* #undef HAVE_BSWAP_16 */
+
+/* Define to 1 if bswap_32 is available. */
+/* #undef HAVE_BSWAP_32 */
+
+/* Define to 1 if bswap_64 is available. */
+/* #undef HAVE_BSWAP_64 */
+
+/* Define to 1 if you have the <byteswap.h> header file. */
+/* #undef HAVE_BYTESWAP_H */
+
+/* Define to 1 if Capsicum is available. */
+/* #undef HAVE_CAPSICUM */
+
+/* Define to 1 if the system has the type `CC_SHA256_CTX'. */
+/* #undef HAVE_CC_SHA256_CTX */
+
+/* Define to 1 if you have the `CC_SHA256_Init' function. */
+/* #undef HAVE_CC_SHA256_INIT */
+
+/* Define to 1 if you have the Mac OS X function CFLocaleCopyCurrent in the
+   CoreFoundation framework. */
+#define HAVE_CFLOCALECOPYCURRENT 1
+
+/* Define to 1 if you have the Mac OS X function CFPreferencesCopyAppValue in
+   the CoreFoundation framework. */
+#define HAVE_CFPREFERENCESCOPYAPPVALUE 1
+
+/* Define to 1 if crc32 integrity check is enabled. */
+#define HAVE_CHECK_CRC32 1
+
+/* Define to 1 if crc64 integrity check is enabled. */
+#define HAVE_CHECK_CRC64 1
+
+/* Define to 1 if sha256 integrity check is enabled. */
+#define HAVE_CHECK_SHA256 1
+
+/* Define to 1 if you have the `clock_gettime' function. */
+#define HAVE_CLOCK_GETTIME 1
+
+/* Define to 1 if you have the <CommonCrypto/CommonDigest.h> header file. */
+/* #undef HAVE_COMMONCRYPTO_COMMONDIGEST_H */
+
+/* Define if the GNU dcgettext() function is already present or preinstalled.
+   */
+/* #undef HAVE_DCGETTEXT */
+
+/* Define to 1 if you have the declaration of `CLOCK_MONOTONIC', and to 0 if
+   you don't. */
+#define HAVE_DECL_CLOCK_MONOTONIC 1
+
+/* Define to 1 if you have the declaration of `program_invocation_name', and
+   to 0 if you don't. */
+#define HAVE_DECL_PROGRAM_INVOCATION_NAME 0
+
+/* Define to 1 if any of HAVE_DECODER_foo have been defined. */
+#define HAVE_DECODERS 1
+
+/* Define to 1 if arm decoder is enabled. */
+#define HAVE_DECODER_ARM 1
+
+/* Define to 1 if armthumb decoder is enabled. */
+#define HAVE_DECODER_ARMTHUMB 1
+
+/* Define to 1 if delta decoder is enabled. */
+#define HAVE_DECODER_DELTA 1
+
+/* Define to 1 if ia64 decoder is enabled. */
+#define HAVE_DECODER_IA64 1
+
+/* Define to 1 if lzma1 decoder is enabled. */
+#define HAVE_DECODER_LZMA1 1
+
+/* Define to 1 if lzma2 decoder is enabled. */
+#define HAVE_DECODER_LZMA2 1
+
+/* Define to 1 if powerpc decoder is enabled. */
+#define HAVE_DECODER_POWERPC 1
+
+/* Define to 1 if sparc decoder is enabled. */
+#define HAVE_DECODER_SPARC 1
+
+/* Define to 1 if x86 decoder is enabled. */
+#define HAVE_DECODER_X86 1
+
+/* Define to 1 if you have the <dlfcn.h> header file. */
+#define HAVE_DLFCN_H 1
+
+/* Define to 1 if any of HAVE_ENCODER_foo have been defined. */
+#define HAVE_ENCODERS 1
+
+/* Define to 1 if arm encoder is enabled. */
+#define HAVE_ENCODER_ARM 1
+
+/* Define to 1 if armthumb encoder is enabled. */
+#define HAVE_ENCODER_ARMTHUMB 1
+
+/* Define to 1 if delta encoder is enabled. */
+#define HAVE_ENCODER_DELTA 1
+
+/* Define to 1 if ia64 encoder is enabled. */
+#define HAVE_ENCODER_IA64 1
+
+/* Define to 1 if lzma1 encoder is enabled. */
+#define HAVE_ENCODER_LZMA1 1
+
+/* Define to 1 if lzma2 encoder is enabled. */
+#define HAVE_ENCODER_LZMA2 1
+
+/* Define to 1 if powerpc encoder is enabled. */
+#define HAVE_ENCODER_POWERPC 1
+
+/* Define to 1 if sparc encoder is enabled. */
+#define HAVE_ENCODER_SPARC 1
+
+/* Define to 1 if x86 encoder is enabled. */
+#define HAVE_ENCODER_X86 1
+
+/* Define to 1 if you have the <fcntl.h> header file. */
+#define HAVE_FCNTL_H 1
+
+/* Define to 1 if you have the `futimens' function. */
+#define HAVE_FUTIMENS 1
+
+/* Define to 1 if you have the `futimes' function. */
+/* #undef HAVE_FUTIMES */
+
+/* Define to 1 if you have the `futimesat' function. */
+/* #undef HAVE_FUTIMESAT */
+
+/* Define to 1 if you have the <getopt.h> header file. */
+#define HAVE_GETOPT_H 1
+
+/* Define to 1 if you have the `getopt_long' function. */
+#define HAVE_GETOPT_LONG 1
+
+/* Define if the GNU gettext() function is already present or preinstalled. */
+/* #undef HAVE_GETTEXT */
+
+/* Define if you have the iconv() function and it works. */
+#define HAVE_ICONV 1
+
+/* Define to 1 if you have the <immintrin.h> header file. */
+/* #undef HAVE_IMMINTRIN_H */
+
+/* Define to 1 if you have the <inttypes.h> header file. */
+#define HAVE_INTTYPES_H 1
+
+/* Define to 1 if you have the <limits.h> header file. */
+#define HAVE_LIMITS_H 1
+
+/* Define to 1 if mbrtowc and mbstate_t are properly declared. */
+#define HAVE_MBRTOWC 1
+
+/* Define to 1 if you have the <memory.h> header file. */
+#define HAVE_MEMORY_H 1
+
+/* Define to 1 to enable bt2 match finder. */
+#define HAVE_MF_BT2 1
+
+/* Define to 1 to enable bt3 match finder. */
+#define HAVE_MF_BT3 1
+
+/* Define to 1 to enable bt4 match finder. */
+#define HAVE_MF_BT4 1
+
+/* Define to 1 to enable hc3 match finder. */
+#define HAVE_MF_HC3 1
+
+/* Define to 1 to enable hc4 match finder. */
+#define HAVE_MF_HC4 1
+
+/* Define to 1 if getopt.h declares extern int optreset. */
+#define HAVE_OPTRESET 1
+
+/* Define to 1 if you have the `posix_fadvise' function. */
+/* #undef HAVE_POSIX_FADVISE */
+
+/* Define to 1 if you have the `pthread_condattr_setclock' function. */
+/* #undef HAVE_PTHREAD_CONDATTR_SETCLOCK */
+
+/* Have PTHREAD_PRIO_INHERIT. */
+#define HAVE_PTHREAD_PRIO_INHERIT 1
+
+/* Define to 1 if you have the `SHA256Init' function. */
+/* #undef HAVE_SHA256INIT */
+
+/* Define to 1 if the system has the type `SHA256_CTX'. */
+/* #undef HAVE_SHA256_CTX */
+
+/* Define to 1 if you have the <sha256.h> header file. */
+/* #undef HAVE_SHA256_H */
+
+/* Define to 1 if you have the `SHA256_Init' function. */
+/* #undef HAVE_SHA256_INIT */
+
+/* Define to 1 if the system has the type `SHA2_CTX'. */
+/* #undef HAVE_SHA2_CTX */
+
+/* Define to 1 if you have the <sha2.h> header file. */
+/* #undef HAVE_SHA2_H */
+
+/* Define to 1 if optimizing for size. */
+/* #undef HAVE_SMALL */
+
+/* Define to 1 if stdbool.h conforms to C99. */
+#define HAVE_STDBOOL_H 1
+
+/* Define to 1 if you have the <stdint.h> header file. */
+#define HAVE_STDINT_H 1
+
+/* Define to 1 if you have the <stdlib.h> header file. */
+#define HAVE_STDLIB_H 1
+
+/* Define to 1 if you have the <strings.h> header file. */
+#define HAVE_STRINGS_H 1
+
+/* Define to 1 if you have the <string.h> header file. */
+#define HAVE_STRING_H 1
+
+/* Define to 1 if `st_atimensec' is a member of `struct stat'. */
+/* #undef HAVE_STRUCT_STAT_ST_ATIMENSEC */
+
+/* Define to 1 if `st_atimespec.tv_nsec' is a member of `struct stat'. */
+#define HAVE_STRUCT_STAT_ST_ATIMESPEC_TV_NSEC 1
+
+/* Define to 1 if `st_atim.st__tim.tv_nsec' is a member of `struct stat'. */
+/* #undef HAVE_STRUCT_STAT_ST_ATIM_ST__TIM_TV_NSEC */
+
+/* Define to 1 if `st_atim.tv_nsec' is a member of `struct stat'. */
+/* #undef HAVE_STRUCT_STAT_ST_ATIM_TV_NSEC */
+
+/* Define to 1 if `st_uatime' is a member of `struct stat'. */
+/* #undef HAVE_STRUCT_STAT_ST_UATIME */
+
+/* Define to 1 if you have the <sys/byteorder.h> header file. */
+/* #undef HAVE_SYS_BYTEORDER_H */
+
+/* Define to 1 if you have the <sys/capsicum.h> header file. */
+/* #undef HAVE_SYS_CAPSICUM_H */
+
+/* Define to 1 if you have the <sys/endian.h> header file. */
+/* #undef HAVE_SYS_ENDIAN_H */
+
+/* Define to 1 if you have the <sys/param.h> header file. */
+#define HAVE_SYS_PARAM_H 1
+
+/* Define to 1 if you have the <sys/stat.h> header file. */
+#define HAVE_SYS_STAT_H 1
+
+/* Define to 1 if you have the <sys/time.h> header file. */
+#define HAVE_SYS_TIME_H 1
+
+/* Define to 1 if you have the <sys/types.h> header file. */
+#define HAVE_SYS_TYPES_H 1
+
+/* Define to 1 if the system has the type `uintptr_t'. */
+#define HAVE_UINTPTR_T 1
+
+/* Define to 1 if you have the <unistd.h> header file. */
+#define HAVE_UNISTD_H 1
+
+/* Define to 1 if you have the `utime' function. */
+/* #undef HAVE_UTIME */
+
+/* Define to 1 if you have the `utimes' function. */
+/* #undef HAVE_UTIMES */
+
+/* Define to 1 or 0, depending whether the compiler supports simple visibility
+   declarations. */
+#define HAVE_VISIBILITY 1
+
+/* Define to 1 if you have the `wcwidth' function. */
+#define HAVE_WCWIDTH 1
+
+/* Define to 1 if the system has the type `_Bool'. */
+#define HAVE__BOOL 1
+
+/* Define to 1 if you have the `_futime' function. */
+/* #undef HAVE__FUTIME */
+
+/* Define to 1 if _mm_movemask_epi8 is available. */
+/* #undef HAVE__MM_MOVEMASK_EPI8 */
+
+/* Define to the sub-directory where libtool stores uninstalled libraries. */
+#define LT_OBJDIR ".libs/"
+
+/* Define to 1 when using POSIX threads (pthreads). */
+#define MYTHREAD_POSIX 1
+
+/* Define to 1 when using Windows Vista compatible threads. This uses features
+   that are not available on Windows XP. */
+/* #undef MYTHREAD_VISTA */
+
+/* Define to 1 when using Windows 95 (and thus XP) compatible threads. This
+   avoids use of features that were added in Windows Vista. */
+/* #undef MYTHREAD_WIN95 */
+
+/* Define to 1 to disable debugging code. */
+#define NDEBUG 1
+
+/* Name of package */
+#define PACKAGE "xz"
+
+/* Define to the address where bug reports for this package should be sent. */
+#define PACKAGE_BUGREPORT "lasse.collin@tukaani.org"
+
+/* Define to the full name of this package. */
+#define PACKAGE_NAME "XZ Utils"
+
+/* Define to the full name and version of this package. */
+#define PACKAGE_STRING "XZ Utils 5.2.3"
+
+/* Define to the one symbol short name of this package. */
+#define PACKAGE_TARNAME "xz"
+
+/* Define to the home page for this package. */
+#define PACKAGE_URL "http://tukaani.org/xz/"
+
+/* Define to the version of this package. */
+#define PACKAGE_VERSION "5.2.3"
+
+/* Define to necessary symbol if this constant uses a non-standard name on
+   your system. */
+/* #undef PTHREAD_CREATE_JOINABLE */
+
+/* The size of `size_t', as computed by sizeof. */
+#define SIZEOF_SIZE_T 4
+
+/* Define to 1 if you have the ANSI C header files. */
+#define STDC_HEADERS 1
+
+/* Define to 1 if the number of available CPU cores can be detected with
+   cpuset(2). */
+/* #undef TUKLIB_CPUCORES_CPUSET */
+
+/* Define to 1 if the number of available CPU cores can be detected with
+   pstat_getdynamic(). */
+/* #undef TUKLIB_CPUCORES_PSTAT_GETDYNAMIC */
+
+/* Define to 1 if the number of available CPU cores can be detected with
+   sched_getaffinity() */
+/* #undef TUKLIB_CPUCORES_SCHED_GETAFFINITY */
+
+/* Define to 1 if the number of available CPU cores can be detected with
+   sysconf(_SC_NPROCESSORS_ONLN) or sysconf(_SC_NPROC_ONLN). */
+/* #undef TUKLIB_CPUCORES_SYSCONF */
+
+/* Define to 1 if the number of available CPU cores can be detected with
+   sysctl(). */
+#define TUKLIB_CPUCORES_SYSCTL 1
+
+/* Define to 1 if the system supports fast unaligned access to 16-bit and
+   32-bit integers. */
+#define TUKLIB_FAST_UNALIGNED_ACCESS 1
+
+/* Define to 1 if the amount of physical memory can be detected with
+   _system_configuration.physmem. */
+/* #undef TUKLIB_PHYSMEM_AIX */
+
+/* Define to 1 if the amount of physical memory can be detected with
+   getinvent_r(). */
+/* #undef TUKLIB_PHYSMEM_GETINVENT_R */
+
+/* Define to 1 if the amount of physical memory can be detected with
+   getsysinfo(). */
+/* #undef TUKLIB_PHYSMEM_GETSYSINFO */
+
+/* Define to 1 if the amount of physical memory can be detected with
+   pstat_getstatic(). */
+/* #undef TUKLIB_PHYSMEM_PSTAT_GETSTATIC */
+
+/* Define to 1 if the amount of physical memory can be detected with
+   sysconf(_SC_PAGESIZE) and sysconf(_SC_PHYS_PAGES). */
+#define TUKLIB_PHYSMEM_SYSCONF 1
+
+/* Define to 1 if the amount of physical memory can be detected with sysctl().
+   */
+/* #undef TUKLIB_PHYSMEM_SYSCTL */
+
+/* Define to 1 if the amount of physical memory can be detected with Linux
+   sysinfo(). */
+/* #undef TUKLIB_PHYSMEM_SYSINFO */
+
+/* Enable extensions on AIX 3, Interix.  */
+#ifndef _ALL_SOURCE
+# define _ALL_SOURCE 1
+#endif
+/* Enable GNU extensions on systems that have them.  */
+#ifndef _GNU_SOURCE
+# define _GNU_SOURCE 1
+#endif
+/* Enable threading extensions on Solaris.  */
+#ifndef _POSIX_PTHREAD_SEMANTICS
+# define _POSIX_PTHREAD_SEMANTICS 1
+#endif
+/* Enable extensions on HP NonStop.  */
+#ifndef _TANDEM_SOURCE
+# define _TANDEM_SOURCE 1
+#endif
+/* Enable general extensions on Solaris.  */
+#ifndef __EXTENSIONS__
+# define __EXTENSIONS__ 1
+#endif
+
+
+/* Version number of package */
+#define VERSION "5.2.3"
+
+/* Define WORDS_BIGENDIAN to 1 if your processor stores words with the most
+   significant byte first (like Motorola and SPARC, unlike Intel). */
+#if defined AC_APPLE_UNIVERSAL_BUILD
+# if defined __BIG_ENDIAN__
+#  define WORDS_BIGENDIAN 1
+# endif
+#else
+# ifndef WORDS_BIGENDIAN
+/* #  undef WORDS_BIGENDIAN */
+# endif
+#endif
+
+/* Enable large inode numbers on Mac OS X 10.5.  */
+#ifndef _DARWIN_USE_64_BIT_INODE
+# define _DARWIN_USE_64_BIT_INODE 1
+#endif
+
+/* Number of bits in a file offset, on hosts where this is settable. */
+/* #undef _FILE_OFFSET_BITS */
+
+/* Define for large files, on AIX-style hosts. */
+/* #undef _LARGE_FILES */
+
+/* Define to 1 if on MINIX. */
+/* #undef _MINIX */
+
+/* Define to 2 if the system does not provide POSIX.1 features except with
+   this defined. */
+/* #undef _POSIX_1_SOURCE */
+
+/* Define to 1 if you need to in order for `stat' and other things to work. */
+/* #undef _POSIX_SOURCE */
+
+/* Define for Solaris 2.5.1 so the uint32_t typedef from <sys/synch.h>,
+   <pthread.h>, or <semaphore.h> is not used. If the typedef were allowed, the
+   #define below would cause a syntax error. */
+/* #undef _UINT32_T */
+
+/* Define for Solaris 2.5.1 so the uint64_t typedef from <sys/synch.h>,
+   <pthread.h>, or <semaphore.h> is not used. If the typedef were allowed, the
+   #define below would cause a syntax error. */
+/* #undef _UINT64_T */
+
+/* Define for Solaris 2.5.1 so the uint8_t typedef from <sys/synch.h>,
+   <pthread.h>, or <semaphore.h> is not used. If the typedef were allowed, the
+   #define below would cause a syntax error. */
+/* #undef _UINT8_T */
+
+/* Define to rpl_ if the getopt replacement functions and variables should be
+   used. */
+/* #undef __GETOPT_PREFIX */
+
+/* Define to the type of a signed integer type of width exactly 32 bits if
+   such a type exists and the standard includes do not define it. */
+/* #undef int32_t */
+
+/* Define to the type of a signed integer type of width exactly 64 bits if
+   such a type exists and the standard includes do not define it. */
+/* #undef int64_t */
+
+/* Define to the type of an unsigned integer type of width exactly 16 bits if
+   such a type exists and the standard includes do not define it. */
+/* #undef uint16_t */
+
+/* Define to the type of an unsigned integer type of width exactly 32 bits if
+   such a type exists and the standard includes do not define it. */
+/* #undef uint32_t */
+
+/* Define to the type of an unsigned integer type of width exactly 64 bits if
+   such a type exists and the standard includes do not define it. */
+/* #undef uint64_t */
+
+/* Define to the type of an unsigned integer type of width exactly 8 bits if
+   such a type exists and the standard includes do not define it. */
+/* #undef uint8_t */
+
+/* Define to the type of an unsigned integer type wide enough to hold a
+   pointer, if such a type exists, and if the system does not define it. */
+/* #undef uintptr_t */

--- a/config.lzma-ios-i386.h
+++ b/config.lzma-ios-i386.h
@@ -1,0 +1,502 @@
+/* config.h.  Generated from config.h.in by configure.  */
+/* config.h.in.  Generated from configure.ac by autoheader.  */
+
+/* Define if building universal (internal helper macro) */
+/* #undef AC_APPLE_UNIVERSAL_BUILD */
+
+/* How many MiB of RAM to assume if the real amount cannot be determined. */
+#define ASSUME_RAM 128
+
+/* Define to 1 if translation of program messages to the user's native
+   language is requested. */
+/* #undef ENABLE_NLS */
+
+/* Define to 1 if bswap_16 is available. */
+/* #undef HAVE_BSWAP_16 */
+
+/* Define to 1 if bswap_32 is available. */
+/* #undef HAVE_BSWAP_32 */
+
+/* Define to 1 if bswap_64 is available. */
+/* #undef HAVE_BSWAP_64 */
+
+/* Define to 1 if you have the <byteswap.h> header file. */
+/* #undef HAVE_BYTESWAP_H */
+
+/* Define to 1 if Capsicum is available. */
+/* #undef HAVE_CAPSICUM */
+
+/* Define to 1 if the system has the type `CC_SHA256_CTX'. */
+/* #undef HAVE_CC_SHA256_CTX */
+
+/* Define to 1 if you have the `CC_SHA256_Init' function. */
+/* #undef HAVE_CC_SHA256_INIT */
+
+/* Define to 1 if you have the Mac OS X function CFLocaleCopyCurrent in the
+   CoreFoundation framework. */
+#define HAVE_CFLOCALECOPYCURRENT 1
+
+/* Define to 1 if you have the Mac OS X function CFPreferencesCopyAppValue in
+   the CoreFoundation framework. */
+#define HAVE_CFPREFERENCESCOPYAPPVALUE 1
+
+/* Define to 1 if crc32 integrity check is enabled. */
+#define HAVE_CHECK_CRC32 1
+
+/* Define to 1 if crc64 integrity check is enabled. */
+#define HAVE_CHECK_CRC64 1
+
+/* Define to 1 if sha256 integrity check is enabled. */
+#define HAVE_CHECK_SHA256 1
+
+/* Define to 1 if you have the `clock_gettime' function. */
+#define HAVE_CLOCK_GETTIME 1
+
+/* Define to 1 if you have the <CommonCrypto/CommonDigest.h> header file. */
+/* #undef HAVE_COMMONCRYPTO_COMMONDIGEST_H */
+
+/* Define if the GNU dcgettext() function is already present or preinstalled.
+   */
+/* #undef HAVE_DCGETTEXT */
+
+/* Define to 1 if you have the declaration of `CLOCK_MONOTONIC', and to 0 if
+   you don't. */
+#define HAVE_DECL_CLOCK_MONOTONIC 1
+
+/* Define to 1 if you have the declaration of `program_invocation_name', and
+   to 0 if you don't. */
+#define HAVE_DECL_PROGRAM_INVOCATION_NAME 0
+
+/* Define to 1 if any of HAVE_DECODER_foo have been defined. */
+#define HAVE_DECODERS 1
+
+/* Define to 1 if arm decoder is enabled. */
+#define HAVE_DECODER_ARM 1
+
+/* Define to 1 if armthumb decoder is enabled. */
+#define HAVE_DECODER_ARMTHUMB 1
+
+/* Define to 1 if delta decoder is enabled. */
+#define HAVE_DECODER_DELTA 1
+
+/* Define to 1 if ia64 decoder is enabled. */
+#define HAVE_DECODER_IA64 1
+
+/* Define to 1 if lzma1 decoder is enabled. */
+#define HAVE_DECODER_LZMA1 1
+
+/* Define to 1 if lzma2 decoder is enabled. */
+#define HAVE_DECODER_LZMA2 1
+
+/* Define to 1 if powerpc decoder is enabled. */
+#define HAVE_DECODER_POWERPC 1
+
+/* Define to 1 if sparc decoder is enabled. */
+#define HAVE_DECODER_SPARC 1
+
+/* Define to 1 if x86 decoder is enabled. */
+#define HAVE_DECODER_X86 1
+
+/* Define to 1 if you have the <dlfcn.h> header file. */
+#define HAVE_DLFCN_H 1
+
+/* Define to 1 if any of HAVE_ENCODER_foo have been defined. */
+#define HAVE_ENCODERS 1
+
+/* Define to 1 if arm encoder is enabled. */
+#define HAVE_ENCODER_ARM 1
+
+/* Define to 1 if armthumb encoder is enabled. */
+#define HAVE_ENCODER_ARMTHUMB 1
+
+/* Define to 1 if delta encoder is enabled. */
+#define HAVE_ENCODER_DELTA 1
+
+/* Define to 1 if ia64 encoder is enabled. */
+#define HAVE_ENCODER_IA64 1
+
+/* Define to 1 if lzma1 encoder is enabled. */
+#define HAVE_ENCODER_LZMA1 1
+
+/* Define to 1 if lzma2 encoder is enabled. */
+#define HAVE_ENCODER_LZMA2 1
+
+/* Define to 1 if powerpc encoder is enabled. */
+#define HAVE_ENCODER_POWERPC 1
+
+/* Define to 1 if sparc encoder is enabled. */
+#define HAVE_ENCODER_SPARC 1
+
+/* Define to 1 if x86 encoder is enabled. */
+#define HAVE_ENCODER_X86 1
+
+/* Define to 1 if you have the <fcntl.h> header file. */
+#define HAVE_FCNTL_H 1
+
+/* Define to 1 if you have the `futimens' function. */
+#define HAVE_FUTIMENS 1
+
+/* Define to 1 if you have the `futimes' function. */
+/* #undef HAVE_FUTIMES */
+
+/* Define to 1 if you have the `futimesat' function. */
+/* #undef HAVE_FUTIMESAT */
+
+/* Define to 1 if you have the <getopt.h> header file. */
+#define HAVE_GETOPT_H 1
+
+/* Define to 1 if you have the `getopt_long' function. */
+#define HAVE_GETOPT_LONG 1
+
+/* Define if the GNU gettext() function is already present or preinstalled. */
+/* #undef HAVE_GETTEXT */
+
+/* Define if you have the iconv() function and it works. */
+#define HAVE_ICONV 1
+
+/* Define to 1 if you have the <immintrin.h> header file. */
+#define HAVE_IMMINTRIN_H 1
+
+/* Define to 1 if you have the <inttypes.h> header file. */
+#define HAVE_INTTYPES_H 1
+
+/* Define to 1 if you have the <limits.h> header file. */
+#define HAVE_LIMITS_H 1
+
+/* Define to 1 if mbrtowc and mbstate_t are properly declared. */
+#define HAVE_MBRTOWC 1
+
+/* Define to 1 if you have the <memory.h> header file. */
+#define HAVE_MEMORY_H 1
+
+/* Define to 1 to enable bt2 match finder. */
+#define HAVE_MF_BT2 1
+
+/* Define to 1 to enable bt3 match finder. */
+#define HAVE_MF_BT3 1
+
+/* Define to 1 to enable bt4 match finder. */
+#define HAVE_MF_BT4 1
+
+/* Define to 1 to enable hc3 match finder. */
+#define HAVE_MF_HC3 1
+
+/* Define to 1 to enable hc4 match finder. */
+#define HAVE_MF_HC4 1
+
+/* Define to 1 if getopt.h declares extern int optreset. */
+#define HAVE_OPTRESET 1
+
+/* Define to 1 if you have the `posix_fadvise' function. */
+/* #undef HAVE_POSIX_FADVISE */
+
+/* Define to 1 if you have the `pthread_condattr_setclock' function. */
+/* #undef HAVE_PTHREAD_CONDATTR_SETCLOCK */
+
+/* Have PTHREAD_PRIO_INHERIT. */
+#define HAVE_PTHREAD_PRIO_INHERIT 1
+
+/* Define to 1 if you have the `SHA256Init' function. */
+/* #undef HAVE_SHA256INIT */
+
+/* Define to 1 if the system has the type `SHA256_CTX'. */
+/* #undef HAVE_SHA256_CTX */
+
+/* Define to 1 if you have the <sha256.h> header file. */
+/* #undef HAVE_SHA256_H */
+
+/* Define to 1 if you have the `SHA256_Init' function. */
+/* #undef HAVE_SHA256_INIT */
+
+/* Define to 1 if the system has the type `SHA2_CTX'. */
+/* #undef HAVE_SHA2_CTX */
+
+/* Define to 1 if you have the <sha2.h> header file. */
+/* #undef HAVE_SHA2_H */
+
+/* Define to 1 if optimizing for size. */
+/* #undef HAVE_SMALL */
+
+/* Define to 1 if stdbool.h conforms to C99. */
+#define HAVE_STDBOOL_H 1
+
+/* Define to 1 if you have the <stdint.h> header file. */
+#define HAVE_STDINT_H 1
+
+/* Define to 1 if you have the <stdlib.h> header file. */
+#define HAVE_STDLIB_H 1
+
+/* Define to 1 if you have the <strings.h> header file. */
+#define HAVE_STRINGS_H 1
+
+/* Define to 1 if you have the <string.h> header file. */
+#define HAVE_STRING_H 1
+
+/* Define to 1 if `st_atimensec' is a member of `struct stat'. */
+/* #undef HAVE_STRUCT_STAT_ST_ATIMENSEC */
+
+/* Define to 1 if `st_atimespec.tv_nsec' is a member of `struct stat'. */
+#define HAVE_STRUCT_STAT_ST_ATIMESPEC_TV_NSEC 1
+
+/* Define to 1 if `st_atim.st__tim.tv_nsec' is a member of `struct stat'. */
+/* #undef HAVE_STRUCT_STAT_ST_ATIM_ST__TIM_TV_NSEC */
+
+/* Define to 1 if `st_atim.tv_nsec' is a member of `struct stat'. */
+/* #undef HAVE_STRUCT_STAT_ST_ATIM_TV_NSEC */
+
+/* Define to 1 if `st_uatime' is a member of `struct stat'. */
+/* #undef HAVE_STRUCT_STAT_ST_UATIME */
+
+/* Define to 1 if you have the <sys/byteorder.h> header file. */
+/* #undef HAVE_SYS_BYTEORDER_H */
+
+/* Define to 1 if you have the <sys/capsicum.h> header file. */
+/* #undef HAVE_SYS_CAPSICUM_H */
+
+/* Define to 1 if you have the <sys/endian.h> header file. */
+/* #undef HAVE_SYS_ENDIAN_H */
+
+/* Define to 1 if you have the <sys/param.h> header file. */
+#define HAVE_SYS_PARAM_H 1
+
+/* Define to 1 if you have the <sys/stat.h> header file. */
+#define HAVE_SYS_STAT_H 1
+
+/* Define to 1 if you have the <sys/time.h> header file. */
+#define HAVE_SYS_TIME_H 1
+
+/* Define to 1 if you have the <sys/types.h> header file. */
+#define HAVE_SYS_TYPES_H 1
+
+/* Define to 1 if the system has the type `uintptr_t'. */
+#define HAVE_UINTPTR_T 1
+
+/* Define to 1 if you have the <unistd.h> header file. */
+#define HAVE_UNISTD_H 1
+
+/* Define to 1 if you have the `utime' function. */
+/* #undef HAVE_UTIME */
+
+/* Define to 1 if you have the `utimes' function. */
+/* #undef HAVE_UTIMES */
+
+/* Define to 1 or 0, depending whether the compiler supports simple visibility
+   declarations. */
+#define HAVE_VISIBILITY 1
+
+/* Define to 1 if you have the `wcwidth' function. */
+#define HAVE_WCWIDTH 1
+
+/* Define to 1 if the system has the type `_Bool'. */
+#define HAVE__BOOL 1
+
+/* Define to 1 if you have the `_futime' function. */
+/* #undef HAVE__FUTIME */
+
+/* Define to 1 if _mm_movemask_epi8 is available. */
+#define HAVE__MM_MOVEMASK_EPI8 1
+
+/* Define to the sub-directory where libtool stores uninstalled libraries. */
+#define LT_OBJDIR ".libs/"
+
+/* Define to 1 when using POSIX threads (pthreads). */
+#define MYTHREAD_POSIX 1
+
+/* Define to 1 when using Windows Vista compatible threads. This uses features
+   that are not available on Windows XP. */
+/* #undef MYTHREAD_VISTA */
+
+/* Define to 1 when using Windows 95 (and thus XP) compatible threads. This
+   avoids use of features that were added in Windows Vista. */
+/* #undef MYTHREAD_WIN95 */
+
+/* Define to 1 to disable debugging code. */
+#define NDEBUG 1
+
+/* Name of package */
+#define PACKAGE "xz"
+
+/* Define to the address where bug reports for this package should be sent. */
+#define PACKAGE_BUGREPORT "lasse.collin@tukaani.org"
+
+/* Define to the full name of this package. */
+#define PACKAGE_NAME "XZ Utils"
+
+/* Define to the full name and version of this package. */
+#define PACKAGE_STRING "XZ Utils 5.2.3"
+
+/* Define to the one symbol short name of this package. */
+#define PACKAGE_TARNAME "xz"
+
+/* Define to the home page for this package. */
+#define PACKAGE_URL "http://tukaani.org/xz/"
+
+/* Define to the version of this package. */
+#define PACKAGE_VERSION "5.2.3"
+
+/* Define to necessary symbol if this constant uses a non-standard name on
+   your system. */
+/* #undef PTHREAD_CREATE_JOINABLE */
+
+/* The size of `size_t', as computed by sizeof. */
+#define SIZEOF_SIZE_T 4
+
+/* Define to 1 if you have the ANSI C header files. */
+#define STDC_HEADERS 1
+
+/* Define to 1 if the number of available CPU cores can be detected with
+   cpuset(2). */
+/* #undef TUKLIB_CPUCORES_CPUSET */
+
+/* Define to 1 if the number of available CPU cores can be detected with
+   pstat_getdynamic(). */
+/* #undef TUKLIB_CPUCORES_PSTAT_GETDYNAMIC */
+
+/* Define to 1 if the number of available CPU cores can be detected with
+   sched_getaffinity() */
+/* #undef TUKLIB_CPUCORES_SCHED_GETAFFINITY */
+
+/* Define to 1 if the number of available CPU cores can be detected with
+   sysconf(_SC_NPROCESSORS_ONLN) or sysconf(_SC_NPROC_ONLN). */
+/* #undef TUKLIB_CPUCORES_SYSCONF */
+
+/* Define to 1 if the number of available CPU cores can be detected with
+   sysctl(). */
+#define TUKLIB_CPUCORES_SYSCTL 1
+
+/* Define to 1 if the system supports fast unaligned access to 16-bit and
+   32-bit integers. */
+#define TUKLIB_FAST_UNALIGNED_ACCESS 1
+
+/* Define to 1 if the amount of physical memory can be detected with
+   _system_configuration.physmem. */
+/* #undef TUKLIB_PHYSMEM_AIX */
+
+/* Define to 1 if the amount of physical memory can be detected with
+   getinvent_r(). */
+/* #undef TUKLIB_PHYSMEM_GETINVENT_R */
+
+/* Define to 1 if the amount of physical memory can be detected with
+   getsysinfo(). */
+/* #undef TUKLIB_PHYSMEM_GETSYSINFO */
+
+/* Define to 1 if the amount of physical memory can be detected with
+   pstat_getstatic(). */
+/* #undef TUKLIB_PHYSMEM_PSTAT_GETSTATIC */
+
+/* Define to 1 if the amount of physical memory can be detected with
+   sysconf(_SC_PAGESIZE) and sysconf(_SC_PHYS_PAGES). */
+#define TUKLIB_PHYSMEM_SYSCONF 1
+
+/* Define to 1 if the amount of physical memory can be detected with sysctl().
+   */
+/* #undef TUKLIB_PHYSMEM_SYSCTL */
+
+/* Define to 1 if the amount of physical memory can be detected with Linux
+   sysinfo(). */
+/* #undef TUKLIB_PHYSMEM_SYSINFO */
+
+/* Enable extensions on AIX 3, Interix.  */
+#ifndef _ALL_SOURCE
+# define _ALL_SOURCE 1
+#endif
+/* Enable GNU extensions on systems that have them.  */
+#ifndef _GNU_SOURCE
+# define _GNU_SOURCE 1
+#endif
+/* Enable threading extensions on Solaris.  */
+#ifndef _POSIX_PTHREAD_SEMANTICS
+# define _POSIX_PTHREAD_SEMANTICS 1
+#endif
+/* Enable extensions on HP NonStop.  */
+#ifndef _TANDEM_SOURCE
+# define _TANDEM_SOURCE 1
+#endif
+/* Enable general extensions on Solaris.  */
+#ifndef __EXTENSIONS__
+# define __EXTENSIONS__ 1
+#endif
+
+
+/* Version number of package */
+#define VERSION "5.2.3"
+
+/* Define WORDS_BIGENDIAN to 1 if your processor stores words with the most
+   significant byte first (like Motorola and SPARC, unlike Intel). */
+#if defined AC_APPLE_UNIVERSAL_BUILD
+# if defined __BIG_ENDIAN__
+#  define WORDS_BIGENDIAN 1
+# endif
+#else
+# ifndef WORDS_BIGENDIAN
+/* #  undef WORDS_BIGENDIAN */
+# endif
+#endif
+
+/* Enable large inode numbers on Mac OS X 10.5.  */
+#ifndef _DARWIN_USE_64_BIT_INODE
+# define _DARWIN_USE_64_BIT_INODE 1
+#endif
+
+/* Number of bits in a file offset, on hosts where this is settable. */
+/* #undef _FILE_OFFSET_BITS */
+
+/* Define for large files, on AIX-style hosts. */
+/* #undef _LARGE_FILES */
+
+/* Define to 1 if on MINIX. */
+/* #undef _MINIX */
+
+/* Define to 2 if the system does not provide POSIX.1 features except with
+   this defined. */
+/* #undef _POSIX_1_SOURCE */
+
+/* Define to 1 if you need to in order for `stat' and other things to work. */
+/* #undef _POSIX_SOURCE */
+
+/* Define for Solaris 2.5.1 so the uint32_t typedef from <sys/synch.h>,
+   <pthread.h>, or <semaphore.h> is not used. If the typedef were allowed, the
+   #define below would cause a syntax error. */
+/* #undef _UINT32_T */
+
+/* Define for Solaris 2.5.1 so the uint64_t typedef from <sys/synch.h>,
+   <pthread.h>, or <semaphore.h> is not used. If the typedef were allowed, the
+   #define below would cause a syntax error. */
+/* #undef _UINT64_T */
+
+/* Define for Solaris 2.5.1 so the uint8_t typedef from <sys/synch.h>,
+   <pthread.h>, or <semaphore.h> is not used. If the typedef were allowed, the
+   #define below would cause a syntax error. */
+/* #undef _UINT8_T */
+
+/* Define to rpl_ if the getopt replacement functions and variables should be
+   used. */
+/* #undef __GETOPT_PREFIX */
+
+/* Define to the type of a signed integer type of width exactly 32 bits if
+   such a type exists and the standard includes do not define it. */
+/* #undef int32_t */
+
+/* Define to the type of a signed integer type of width exactly 64 bits if
+   such a type exists and the standard includes do not define it. */
+/* #undef int64_t */
+
+/* Define to the type of an unsigned integer type of width exactly 16 bits if
+   such a type exists and the standard includes do not define it. */
+/* #undef uint16_t */
+
+/* Define to the type of an unsigned integer type of width exactly 32 bits if
+   such a type exists and the standard includes do not define it. */
+/* #undef uint32_t */
+
+/* Define to the type of an unsigned integer type of width exactly 64 bits if
+   such a type exists and the standard includes do not define it. */
+/* #undef uint64_t */
+
+/* Define to the type of an unsigned integer type of width exactly 8 bits if
+   such a type exists and the standard includes do not define it. */
+/* #undef uint8_t */
+
+/* Define to the type of an unsigned integer type wide enough to hold a
+   pointer, if such a type exists, and if the system does not define it. */
+/* #undef uintptr_t */

--- a/test/BUILD
+++ b/test/BUILD
@@ -595,7 +595,7 @@ cc_test(
 config_setting(
     name = "windows",
     constraint_values = [
-        "@bazel_tools//platforms:windows",
+        "@platforms//os:windows",
     ],
     visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
Thank you, @nelhage, for an amazingly helpful set of rules!

I took a solid crack at adding support for iOS, watchOS, and tvOS this evening. (We just switched to using Bazel's @platforms// via a platform_mappings file.) I'm hoping you'd consider taking it as a contribution!

This commit was meant to be the simplest, most readable implementation change that I thought would work, for ease of review. So it's just adding parallel cases--plus a few places where I couldn't resist massaging some selects->with_or that'd simplify the cases I was adding.

Independently and subsequently, we may well want to do a pass over the repo, where we move the deprecated @bazel_tools//platforms constraint_value()s over to the @platforms//  constraint_value()s they're aliases of, but that's probably best separated to keep things small. We might want to just directly use the constraint_values in selects at the same time, to eliminate some boilerplate. [Edit: This doesn't fully work until Bazel 6.] But that can wait. Lmk, though, if there's a reason we shouldn't do that.

To head off a couple things that might look wrong but are intentional:
watchOS and tvOS don't have @bazel_tools//platforms equivalents, so I used their shiny new @platforms// paths off the bat. Inconsistency necessary, unfortunately.
The Apple toolchains do indeed (mis)use arm for armv7 and armv7k --those aren't typos.

Obviously, feel free to modify whatever. Looking forward to hearing what you think!

Thanks for your consideration!
Chris

P.S. Details on how I got the lzma configs, saved to the end for readability.
Grabbed version 5.2.3 from source forge, parallel to boost.bzl.
Ran this to generate configs the distinct, new configs you see added:
```
rm config.h
CC="clang -arch arm64 \
-isysroot /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk" \
./configure --host=x86_64-apple-darwin21.2.0
cp config.h ~/Downloads/rules_boost/config.lzma-ios-arm64.h


rm config.h
CC="clang -arch armv7 \
-isysroot /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk" \
./configure --host=x86_64-apple-darwin21.2.0
cp config.h ~/Downloads/rules_boost/config.lzma-ios-armv7.h

rm config.h
CC="clang -arch i386 \
-isysroot /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator.sdk" \
./configure --host=x86_64-apple-darwin21.2.0
cp config.h ~/Downloads/rules_boost/config.lzma-ios-i386.h
```
And I did some checks to eliminate ones that were duplicates. For example, iOS x86_64 is the same as the existing macOS x86_64.
```
rm config.h
CC="clang -arch x86_64 \
-isysroot /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator.sdk" \
./configure --host=x86_64-apple-darwin21.2.0
cp config.h ~/Downloads/rules_boost/config.lzma-ios-x86_64.h
```
And armv7k for watchOS was the same as armv7 for iOS.
```
rm config.h
CC="clang -arch armv7k \
-isysroot /Applications/Xcode.app/Contents/Developer/Platforms/WatchOS.platform/Developer/SDKs/WatchOS.sdk" \
./configure --host=x86_64-apple-darwin21.2.0
cp config.h ~/Downloads/rules_boost/config.lzma-watchos-armv7k.h
```
