### PR TITLE
Swap config_setting(constraint_values=[X]) -> X, where possible

### DIFF
--- a/BUILD.boost
+++ b/BUILD.boost
@@ -4,67 +4,13 @@ load("@bazel_skylib//rules:common_settings.bzl", "bool_flag")
 load("@com_github_nelhage_rules_boost//:boost/boost.bzl", "boost_library", "boost_so_library", "hdr_list")
 
 _w_no_deprecated = selects.with_or({
-    (":linux", ":osx", ":ios", ":watchos", ":tvos"): [
+    ("@platforms//os:linux", "@platforms//os:osx", "@platforms//os:ios", "@platforms//os:watchos", "@platforms//os:tvos"): [
         "-Wno-deprecated-declarations",
     ],
     "//conditions:default": [],
 })
 
-config_setting(
-    name = "linux",
-    constraint_values = [
-        "@platforms//os:linux",
-    ],
-    visibility = ["//visibility:public"],
-)
-
-config_setting(
-    name = "android",
-    constraint_values = [
-        "@platforms//os:android",
-    ],
-    visibility = ["//visibility:public"],
-)
-
-config_setting(
-    name = "osx",
-    constraint_values = [
-        "@platforms//os:osx",
-    ],
-    visibility = ["//visibility:public"],
-)
-
-config_setting(
-    name = "ios",
-    constraint_values = [
-        "@platforms//os:ios",
-    ],
-    visibility = ["//visibility:public"],
-)
-
-config_setting(
-    name = "watchos",
-    constraint_values = [
-        "@platforms//os:watchos",
-    ],
-    visibility = ["//visibility:public"],
-)
-
-config_setting(
-    name = "tvos",
-    constraint_values = [
-        "@platforms//os:tvos",
-    ],
-    visibility = ["//visibility:public"],
-)
-
-config_setting(
-    name = "windows",
-    constraint_values = [
-        "@platforms//os:windows",
-    ],
-    visibility = ["//visibility:public"],
-)
+# Hopefully, the need for these OSxCPU config_setting()s will be obviated by a fix to https://github.com/bazelbuild/platforms/issues/36
 
 config_setting(
     name = "linux_arm",
@@ -72,7 +18,6 @@ config_setting(
         "@platforms//os:linux",
         "@platforms//cpu:arm",
     ],
-    visibility = ["//visibility:public"],
 )
 
 config_setting(
@@ -81,7 +26,6 @@ config_setting(
         "@platforms//os:linux",
         "@platforms//cpu:ppc",
     ],
-    visibility = ["//visibility:public"],
 )
 
 config_setting(
@@ -90,7 +34,6 @@ config_setting(
         "@platforms//os:linux",
         "@platforms//cpu:aarch64",
     ],
-    visibility = ["//visibility:public"],
 )
 
 config_setting(
@@ -99,7 +42,6 @@ config_setting(
         "@platforms//os:linux",
         "@platforms//cpu:x86_64",
     ],
-    visibility = ["//visibility:public"],
 )
 
 config_setting(
@@ -108,7 +50,6 @@ config_setting(
         "@platforms//os:osx",
         "@platforms//cpu:aarch64",
     ],
-    visibility = ["//visibility:public"],
 )
 
 config_setting(
@@ -117,7 +58,6 @@ config_setting(
         "@platforms//os:osx",
         "@platforms//cpu:x86_64",
     ],
-    visibility = ["//visibility:public"],
 )
 
 config_setting(
@@ -126,15 +66,6 @@ config_setting(
         "@platforms//os:windows",
         "@platforms//cpu:x86_64",
     ],
-    visibility = ["//visibility:public"],
-)
-
-config_setting(
-    name = "x86_64",
-    constraint_values = [
-        "@platforms//cpu:x86_64",
-    ],
-    visibility = ["//visibility:public"],
 )
 
 config_setting(
@@ -143,7 +74,6 @@ config_setting(
         "@platforms//os:android",
         "@platforms//cpu:arm",
     ],
-    visibility = ["//visibility:public"],
 )
 
 config_setting(
@@ -152,7 +82,6 @@ config_setting(
         "@platforms//os:android",
         "@platforms//cpu:aarch64",
     ],
-    visibility = ["//visibility:public"],
 )
 
 # Rename .asm to .S so that it will be handled with the C preprocessor.
@@ -187,7 +116,7 @@ BOOST_CTX_ASM_SOURCES = selects.with_or({
         "libs/context/src/asm/make_x86_64_sysv_elf_gas.S",
         "libs/context/src/asm/ontop_x86_64_sysv_elf_gas.S",
     ],
-    (":osx", ":ios", ":watchos", ":tvos") : ["apple_ctx_asm_sources"],
+    ("@platforms//os:osx", "@platforms//os:ios", "@platforms//os:watchos", "@platforms//os:tvos") : ["apple_ctx_asm_sources"],
     ":windows_x86_64": [
         "libs/context/src/asm/make_x86_64_ms_pe_masm.S",
         "libs/context/src/asm/jump_x86_64_ms_pe_masm.S",
@@ -220,7 +149,7 @@ filegroup(
 boost_library(
     name = "context",
     srcs = BOOST_CTX_ASM_SOURCES + selects.with_or({
-        (":linux", ":android", ":osx", ":ios", ":watchos", ":tvos"): [
+        ("@platforms//os:linux", "@platforms//os:android", "@platforms//os:osx", "@platforms//os:ios", "@platforms//os:watchos", "@platforms//os:tvos"): [
             "libs/context/src/posix/stack_traits.cpp",
         ],
         ":windows_x86_64": [
@@ -284,7 +213,7 @@ boost_library(
     }),
     exclude_src = ["libs/fiber/src/numa/**/*.cpp"],
     linkopts = selects.with_or({
-        (":linux", ":osx", ":ios", ":watchos", ":tvos"): ["-lpthread"],
+        ("@platforms//os:linux", "@platforms//os:osx", "@platforms//os:ios", "@platforms//os:watchos", "@platforms//os:tvos"): ["-lpthread"],
         "//conditions:default": [],
     }),
     visibility = ["//visibility:public"],
@@ -410,7 +339,7 @@ boost_library(
     copts = ["-Iexternal/boost/libs/atomic/src"],
     exclude_src = ["libs/atomic/src/wait_on_address.cpp"] + BOOST_ATOMIC_SSE_SRCS,
     deps = BOOST_ATOMIC_DEPS + select({
-        ":x86_64": [":atomic_sse"],
+        "@platforms//cpu:x86_64": [":atomic_sse"],
         "//conditions:default": [],
     }),
 )
@@ -475,7 +404,7 @@ boost_library(
     defines = [
         "BOOST_ASIO_SEPARATE_COMPILATION",
     ] + selects.with_or({
-        (":osx", ":ios", ":watchos", ":tvos"): [
+        ("@platforms//os:osx", "@platforms//os:ios", "@platforms//os:watchos", "@platforms//os:tvos"): [
             "BOOST_ASIO_DISABLE_STD_EXPERIMENTAL_STRING_VIEW",
         ],
         "//conditions:default": [],
@@ -487,7 +416,7 @@ boost_library(
         "//conditions:default": [],
     }),
     linkopts = select({
-        ":android": [],
+        "@platforms//os:android": [],
         "//conditions:default": ["-lpthread"],
     }) + select({
         ":asio_io_uring": ["-luring"],
@@ -632,7 +561,7 @@ boost_library(
     linkopts = selects.with_or({
         # OpenCL (required for Boost.Compute) is deprecated on macOS and not supported on other Apple OSs.
         # This will at least produce the right error message, indicating that OpenCL is not present
-        (":osx", ":ios", ":watchos", ":tvos"): [
+        ("@platforms//os:osx", "@platforms//os:ios", "@platforms//os:watchos", "@platforms//os:tvos"): [
             "-framework OpenCL", 
         ],
         "//conditions:default": [
@@ -733,7 +662,7 @@ boost_library(
 )
 
 BOOST_CORO_SRCS = selects.with_or({
-    (":linux", ":android", ":osx", ":ios", ":watchos", ":tvos"): [
+    ("@platforms//os:linux", "@platforms//os:android", "@platforms//os:osx", "@platforms//os:ios", "@platforms//os:watchos", "@platforms//os:tvos"): [
         "libs/coroutine/src/posix/stack_traits.cpp",
     ],
     ":windows_x86_64": [
@@ -1069,7 +998,7 @@ boost_library(
 boost_library(
     name = "interprocess",
     linkopts = select({
-        ":linux": [
+        "@platforms//os:linux": [
             "-lpthread",
             "-lrt",
         ],
@@ -1243,13 +1172,13 @@ BOOST_LOCALE_WIN32_COPTS = [
 boost_library(
     name = "locale",
     srcs = selects.with_or({
-        ":android": BOOST_LOCALE_STD_SOURCES,
-        (":linux", ":osx", ":ios", ":watchos", ":tvos"): BOOST_LOCALE_POSIX_SOURCES,
+        "@platforms//os:android": BOOST_LOCALE_STD_SOURCES,
+        ("@platforms//os:linux", "@platforms//os:osx", "@platforms//os:ios", "@platforms//os:watchos", "@platforms//os:tvos"): BOOST_LOCALE_POSIX_SOURCES,
         ":windows_x86_64": BOOST_LOCALE_WIN32_SOURCES,
     }),
     copts = selects.with_or({
-        ":android": BOST_LOCALE_STD_COPTS,
-        (":linux", ":osx", ":ios", ":watchos", ":tvos"): BOOST_LOCALE_POSIX_COPTS,
+        "@platforms//os:android": BOST_LOCALE_STD_COPTS,
+        ("@platforms//os:linux", "@platforms//os:osx", "@platforms//os:ios", "@platforms//os:watchos", "@platforms//os:tvos"): BOOST_LOCALE_POSIX_COPTS,
         ":windows_x86_64": BOOST_LOCALE_WIN32_COPTS,
     }) + _w_no_deprecated,
     deps = [
@@ -1476,7 +1405,7 @@ boost_library(
         "boost/numeric/odeint.hpp",
     ],
     linkopts = select({
-        "@boost//:android": ["-lm"],
+        "@platforms//os:android": ["-lm"],
         "//conditions:default": [],
     }),
     deps = [
@@ -1631,7 +1560,7 @@ boost_library(
 boost_library(
     name = "qvm",
     linkopts = select({
-        "@boost//:android": ["-lm"],
+        "@platforms//os:android": ["-lm"],
         "//conditions:default": [],
     }),
     deps = [
@@ -1881,7 +1810,7 @@ boost_library(
 )
 
 BOOST_STACKTRACE_SOURCES = selects.with_or({
-    ":android": [
+    "@platforms//os:android": [
         "libs/stacktrace/src/basic.cpp",
         #"libs/stacktrace/src/noop.cpp",
     ],
@@ -1899,7 +1828,7 @@ BOOST_STACKTRACE_SOURCES = selects.with_or({
     ":linux_x86_64": [
         "libs/stacktrace/src/backtrace.cpp",
     ],
-    (":osx", ":ios", ":watchos", ":tvos"): [
+    ("@platforms//os:osx", "@platforms//os:ios", "@platforms//os:watchos", "@platforms//os:tvos"): [
         "libs/stacktrace/src/addr2line.cpp",
     ],
     ":windows_x86_64": [
@@ -1913,7 +1842,7 @@ boost_library(
     name = "stacktrace",
     srcs = BOOST_STACKTRACE_SOURCES,
     defines = selects.with_or({
-        (":osx", ":ios", ":watchos", ":tvos"): [
+        ("@platforms//os:osx", "@platforms//os:ios", "@platforms//os:watchos", "@platforms//os:tvos"): [
             "BOOST_STACKTRACE_GNU_SOURCE_NOT_REQUIRED",
         ],
         "//conditions:default": [],
@@ -2004,7 +1933,7 @@ boost_library(
 boost_library(
     name = "thread",
     srcs = selects.with_or({
-        (":linux", ":android", ":osx", ":ios", ":watchos", ":tvos"): [
+        ("@platforms//os:linux", "@platforms//os:android", "@platforms//os:osx", "@platforms//os:ios", "@platforms//os:watchos", "@platforms//os:tvos"): [
             "libs/thread/src/pthread/once.cpp",
             "libs/thread/src/pthread/thread.cpp",
         ],
@@ -2015,18 +1944,18 @@ boost_library(
         ],
     }),
     hdrs = selects.with_or({
-        (":linux", ":android", ":osx", ":ios", ":watchos", ":tvos"): [
+        ("@platforms//os:linux", "@platforms//os:android", "@platforms//os:osx", "@platforms//os:ios", "@platforms//os:watchos", "@platforms//os:tvos"): [
             "libs/thread/src/pthread/once_atomic.cpp",
         ],
         ":windows_x86_64": [],
     }),
     linkopts = selects.with_or({
-        (":linux", ":osx", ":ios", ":watchos", ":tvos"): ["-lpthread"],
+        ("@platforms//os:linux", "@platforms//os:osx", "@platforms//os:ios", "@platforms//os:watchos", "@platforms//os:tvos"): ["-lpthread"],
         ":windows_x86_64": [],
-        ":android": [],
+        "@platforms//os:android": [],
     }),
     local_defines = selects.with_or({
-        (":linux", ":osx", ":ios", ":watchos", ":tvos"): [],
+        ("@platforms//os:linux", "@platforms//os:osx", "@platforms//os:ios", "@platforms//os:watchos", "@platforms//os:tvos"): [],
         ":windows_x86_64": [
             "BOOST_ALL_NO_LIB",
             "BOOST_THREAD_BUILD_LIB",
@@ -2354,7 +2283,7 @@ boost_library(
 )
 
 BOOST_LOG_CFLAGS = select({
-    ":x86_64": [
+    "@platforms//cpu:x86_64": [
         "-msse4.2",
     ],
     "//conditions:default": [
@@ -2385,7 +2314,7 @@ BOOST_LOG_DEPS = [
 ]
 
 BOOST_LOG_SSSE3_DEP = select({
-    ":x86_64": [
+    "@platforms//cpu:x86_64": [
         ":log_dump_ssse3",
     ],
     "//conditions:default": [

--- a/BUILD.lzma
+++ b/BUILD.lzma
@@ -5,10 +5,7 @@
 load("@bazel_skylib//rules:copy_file.bzl", "copy_file")
 load("@bazel_skylib//lib:selects.bzl", "selects")
 
-config_setting(
-    name = "linux",
-    constraint_values = ["@platforms//os:linux"],
-)
+# Hopefully, the need for these OSxCPU config_setting()s will be obviated by a fix to https://github.com/bazelbuild/platforms/issues/36
 
 config_setting(
     name = "osx_arm64",
@@ -26,68 +23,15 @@ config_setting(
     ],
 )
 
-config_setting(
-    name = "ios",
-    constraint_values = [
-        "@platforms//os:ios",
-    ],
-)
-
-config_setting(
-    name = "watchos",
-    constraint_values = [
-        "@platforms//os:watchos",
-    ],
-    visibility = ["//visibility:public"],
-)
-
-config_setting(
-    name = "tvos",
-    constraint_values = [
-        "@platforms//os:tvos",
-    ],
-    visibility = ["//visibility:public"],
-)
-
-config_setting(
-    name = "windows",
-    constraint_values = ["@platforms//os:windows"],
-)
-
-config_setting(
-    name = "android",
-    constraint_values = ["@platforms//os:android"],
-)
-
-config_setting(
-    name = "arm",
-    constraint_values = ["@platforms//cpu:arm"],
-)
-
-config_setting(
-    name = "aarch64",
-    constraint_values = ["@platforms//cpu:aarch64"],
-)
-
-config_setting(
-    name = "x86_64",
-    constraint_values = ["@platforms//cpu:x86_64"],
-)
-
-config_setting(
-    name = "x86_32",
-    constraint_values = ["@platforms//cpu:x86_32"],
-)
-
 copy_file(
     name = "copy_config",
     src = selects.with_or({
-        ":android": "@com_github_nelhage_rules_boost//:config.lzma-android.h",
-        ":linux": "@com_github_nelhage_rules_boost//:config.lzma-linux.h",
+        "@platforms//os:android": "@com_github_nelhage_rules_boost//:config.lzma-android.h",
+        "@platforms//os:linux": "@com_github_nelhage_rules_boost//:config.lzma-linux.h",
         ":osx_arm64": "@com_github_nelhage_rules_boost//:config.lzma-osx-arm64.h",
         ":osx_x86_64": "@com_github_nelhage_rules_boost//:config.lzma-osx-x86_64.h",
-        (":ios", ":watchos", ":tvos"): "apple_config",
-        ":windows": "@com_github_nelhage_rules_boost//:config.lzma-windows.h",
+        ("@platforms//os:ios", "@platforms//os:watchos", "@platforms//os:tvos"): "apple_config",
+        "@platforms//os:windows": "@com_github_nelhage_rules_boost//:config.lzma-windows.h",
     }),
     out = "src/liblzma/api/config.h", # minimize the number of exported include paths
 )
@@ -101,6 +45,32 @@ alias(
         ":x86_64": "config.lzma-osx-x86_64.h", # Configuration same as macOS
         ":x86_32": "config.lzma-ios-i386.h",
     }),
+)
+
+# Longer term TODO: Blocked until at least after Bazel 5.1 has been released.
+# config_setting()s wrappers for constraint_values are necessary for alias rules in Bazel because of a bug in 5.0
+# Needs release of fix to https://github.com/bazelbuild/bazel/issues/13047, which will likely happen in 5.1
+# At that time, remove these config settings below and update their use in the alias above to the raw @platforms//os constraint_value()s
+# Note: There are other instances of this message to update or resolve in sync.
+
+config_setting(
+    name = "aarch64",
+    constraint_values = ["@platforms//cpu:aarch64"],
+)
+
+config_setting(
+    name = "arm",
+    constraint_values = ["@platforms//cpu:arm"],
+)
+
+config_setting(
+    name = "x86_64",
+    constraint_values = ["@platforms//cpu:x86_64"],
+)
+
+config_setting(
+    name = "x86_32",
+    constraint_values = ["@platforms//cpu:x86_32"],
 )
 
 cc_library(
@@ -199,7 +169,7 @@ cc_library(
         "src/liblzma/api/lzma/vli.h",
     ],
     copts = select({
-        ":windows": [],
+        "@platforms//os:windows": [],
         "//conditions:default": ["-std=c99"],
     }) + [
         "-I external/org_lzma_lzma/src/common",
@@ -214,18 +184,18 @@ cc_library(
         "-I external/org_lzma_lzma/src/liblzma/simple",
     ],
     defines = select({
-        ":windows": ["LZMA_API_STATIC"],
+        "@platforms//os:windows": ["LZMA_API_STATIC"],
         "//conditions:default": [],
     }),
     includes = [
         "src/liblzma/api",
     ],
     linkopts = select({
-        ":android": [],
+        "@platforms//os:android": [],
         "//conditions:default": ["-lpthread"],
     }),
     linkstatic = select({
-        ":windows": True,
+        "@platforms//os:windows": True,
         "//conditions:default": False,
     }),
     local_defines = [

--- a/BUILD.zlib
+++ b/BUILD.zlib
@@ -11,12 +11,17 @@ alias(
     })
 )
 
+# Longer term TODO: Blocked until at least after Bazel 5.1 has been released.
+# config_setting()s wrappers for constraint_values are necessary for alias rules in Bazel because of a bug in 5.0
+# Needs release of fix to https://github.com/bazelbuild/bazel/issues/13047, which will likely happen in 5.1
+# At that time, remove these config settings below and update their use in the alias above to the raw @platforms//os constraint_value()s
+# Note: There are other instances of this message to update or resolve in sync.
+
 config_setting(
     name = "android",
     constraint_values = [
         "@platforms//os:android",
     ],
-    visibility = ["//visibility:public"],
 )
 
 config_setting(
@@ -24,7 +29,6 @@ config_setting(
     constraint_values = [
         "@platforms//os:ios",
     ],
-    visibility = ["//visibility:public"],
 )
 
 config_setting(
@@ -32,7 +36,6 @@ config_setting(
     constraint_values = [
         "@platforms//os:watchos",
     ],
-    visibility = ["//visibility:public"],
 )
 
 config_setting(
@@ -40,7 +43,6 @@ config_setting(
     constraint_values = [
         "@platforms//os:tvos",
     ],
-    visibility = ["//visibility:public"],
 )
 
 cc_library(
@@ -74,12 +76,12 @@ cc_library(
     ],
     hdrs = ["zlib.h"],
     copts = select({
-        "@boost//:windows": [],
+        "@platforms//os:windows": [],
         "//conditions:default": ["-Wno-shift-negative-value"],
     }),
     includes = ["."],
     local_defines = select({
-        "@boost//:windows": [],
+        "@platforms//os:windows": [],
         "//conditions:default": ["Z_HAVE_UNISTD_H"],
     }),
 )

--- a/BUILD.zstd
+++ b/BUILD.zstd
@@ -34,6 +34,8 @@ cc_library(
     visibility = ["//visibility:public"],
 )
 
+# Hopefully, the need for these OSxCPU config_setting()s will be obviated by a fix to https://github.com/bazelbuild/platforms/issues/36
+
 config_setting(
     name = "linux_x86_64",
     constraint_values = [

--- a/boost/boost.bzl
+++ b/boost/boost.bzl
@@ -20,7 +20,7 @@ srcs_patterns = [
 # Building boost results in many warnings for unused values. Downstream users
 # won't be interested, so just disable the warning.
 default_copts = select({
-    "@boost//:windows": [],
+    "@platforms//os:windows": [],
     "//conditions:default": ["-Wno-unused"],
 })
 

--- a/test/BUILD
+++ b/test/BUILD
@@ -592,19 +592,11 @@ cc_test(
     ],
 )
 
-config_setting(
-    name = "windows",
-    constraint_values = [
-        "@platforms//os:windows",
-    ],
-    visibility = ["//visibility:public"],
-)
-
 cc_test(
     name = "pfr_test",
     srcs = ["pfr_test.cc"],
     copts = select({
-        ":windows": ["/std:c++17"],
+        "@platforms//os:windows": ["/std:c++17"],
         "//conditions:default": ["-std=c++1z"],
     }),
     deps = [


### PR DESCRIPTION
Hey, @nelhage, I went through the last category of cleanup I'd mentioned in #245 and did as much as could be done with Bazel 5. 

To flag the bit that might be controversial: this does remove, e.g. @boost//:windows, as part of the public interface of these rules, but I think you probably want people using Bazel's @platforms// rather than no-longer-needed wrappings in this workspace.

--- 

More details from the commit message:
Bazel no longer requires wrapping single constraint_value()s in config settings; they can be selected upon directly. This allows for some code to deleted and simplified.

I've also added notes to the cases where we can't yet delete constraint_values, but will likely be able to in the near future, as well as the relevant blocking bugs.