### PR TITLE
C++1z -> C++17

### DIFF
--- a/test/BUILD
+++ b/test/BUILD
@@ -605,7 +605,7 @@ cc_test(
     srcs = ["pfr_test.cc"],
     copts = select({
         ":windows": ["/std:c++17"],
-        "//conditions:default": ["-std=c++1z"],
+        "//conditions:default": ["-std=c++17"],
     }),
     deps = [
         "@boost//:pfr",


### PR DESCRIPTION
I happened to see a C++1z while writing #247. Since it's 2022, I figured I'd quickly propose switching it out for C++17.