### PR TITLE
Upgrade boost to 1.79.0

### DIFF
--- a/boost/boost.bzl
+++ b/boost/boost.bzl
@@ -211,10 +211,10 @@ def boost_deps():
         build_file = "@com_github_nelhage_rules_boost//:BUILD.boost",
         patch_cmds = ["rm -f doc/pdf/BUILD"],
         patch_cmds_win = ["Remove-Item -Force doc/pdf/BUILD"],
-        sha256 = "94ced8b72956591c4775ae2207a9763d3600b30d9d7446562c552f0a14a63be7",
-        strip_prefix = "boost_1_78_0",
+        sha256 = "273f1be93238a068aba4f9735a4a2b003019af067b9c183ed227780b8f36062c",
+        strip_prefix = "boost_1_79_0",
         urls = [
-            "https://boostorg.jfrog.io/artifactory/main/release/1.78.0/source/boost_1_78_0.tar.gz",
+            "https://boostorg.jfrog.io/artifactory/main/release/1.79.0/source/boost_1_79_0.tar.gz",
         ],
     )
 


### PR DESCRIPTION
As far as I can tell upgrading to 1.79.0 (released two days ago, on April 13) just works. I tested this locally on Linux and in CircleCI.