### PR TITLE
Add patch 0001 for 1.79

### DIFF
--- a/0001-json-array-erase-relocate.patch
+++ b/0001-json-array-erase-relocate.patch
@@ -1,0 +1,49 @@
+diff -ur boost/json/impl/array.ipp boost/json/impl/array.ipp
+--- boost/json/impl/array.ipp	2022-04-06 17:02:43.000000000 -0400
++++ boost/json/impl/array.ipp	2022-04-13 20:55:20.464359478 -0400
+@@ -491,8 +491,11 @@
+     auto const p = &(*t_)[0] +
+         (pos - &(*t_)[0]);
+     destroy(p, p + 1);
+-    relocate(p, p + 1, 1);
+     --t_->size;
++    if(t_->size > 0)
++        relocate(p, p + 1,
++            t_->size - (p -
++                &(*t_)[0]));
+     return p;
+ }
+ 
+diff -ur libs/json/test/array.cpp libs/json/test/array.cpp
+--- libs/json/test/array.cpp	2022-04-06 17:02:43.000000000 -0400
++++ libs/json/test/array.cpp	2022-04-13 20:53:32.671782680 -0400
+@@ -1270,6 +1270,21 @@
+     }
+ 
+     void
++    testIssue692()
++    {
++	    array a;
++	    object obj;
++	    obj["test1"] = "hello";
++	    a.push_back(obj);
++	    a.push_back(obj);
++	    a.push_back(obj);
++	    a.push_back(obj);
++	    a.push_back(obj);
++	    while(a.size())
++		    a.erase(a.begin());
++    }
++
++    void
+     run()
+     {
+         testDestroy();
+@@ -1283,6 +1298,7 @@
+         testExceptions();
+         testEquality();
+         testHash();
++        testIssue692();
+     }
+ };
+ 

--- a/boost/boost.bzl
+++ b/boost/boost.bzl
@@ -209,6 +209,7 @@ def boost_deps():
         http_archive,
         name = "boost",
         build_file = "@com_github_nelhage_rules_boost//:BUILD.boost",
+        patches = ["@com_github_nelhage_rules_boost//:0001-json-array-erase-relocate.patch"],
         patch_cmds = ["rm -f doc/pdf/BUILD"],
         patch_cmds_win = ["Remove-Item -Force doc/pdf/BUILD"],
         sha256 = "273f1be93238a068aba4f9735a4a2b003019af067b9c183ed227780b8f36062c",


### PR DESCRIPTION
https://www.boost.org/patches/1_79_0/0001-json-array-erase-relocate.patch

Removed boost_1_79_0 prefix from patch path