### PR TITLE
Fix zlib.net link to now non-current 1.2.11

### DIFF
--- a/boost/boost.bzl
+++ b/boost/boost.bzl
@@ -167,7 +167,7 @@ def boost_deps():
         strip_prefix = "zlib-1.2.11",
         urls = [
             "https://mirror.bazel.build/zlib.net/zlib-1.2.11.tar.gz",
-            "https://zlib.net/zlib-1.2.11.tar.gz",
+            "https://zlib.net/fossils/zlib-1.2.11.tar.gz",
         ],
     )
 

--- a/boost/boost.bzl
+++ b/boost/boost.bzl
@@ -163,7 +163,7 @@ def boost_deps():
         http_archive,
         name = "net_zlib_zlib",
         build_file = "@com_github_nelhage_rules_boost//:BUILD.zlib",
-        sha256 = "c3e5e9fdd5004dcb542feda5ee4f0ff0744628baf8ed2dd5d66f8ca1197cb1a1",
+        sha256 = "91844808532e5ce316b3c010929493c0244f3d37593afd6de04f71821d5136d9",
         strip_prefix = "zlib-1.2.12",
         urls = [
             "https://mirror.bazel.build/zlib.net/zlib-1.2.12.tar.gz",

--- a/boost/boost.bzl
+++ b/boost/boost.bzl
@@ -164,10 +164,10 @@ def boost_deps():
         name = "net_zlib_zlib",
         build_file = "@com_github_nelhage_rules_boost//:BUILD.zlib",
         sha256 = "c3e5e9fdd5004dcb542feda5ee4f0ff0744628baf8ed2dd5d66f8ca1197cb1a1",
-        strip_prefix = "zlib-1.2.11",
+        strip_prefix = "zlib-1.2.12",
         urls = [
-            "https://mirror.bazel.build/zlib.net/zlib-1.2.11.tar.gz",
-            "https://zlib.net/fossils/zlib-1.2.11.tar.gz",
+            "https://mirror.bazel.build/zlib.net/zlib-1.2.12.tar.gz",
+            "https://zlib.net/fossils/zlib-1.2.12.tar.gz",
         ],
     )
 


### PR DESCRIPTION
As my current windows/bazel combination fails to use "mirror.bazel" due to cert-stuff, i observed, that the alternative zlib.net link is dead.

As there has been a new release, i guess, the old archive has been dropped. It's available howewer at some other URL which this what this commit updates. 