### PR TITLE
Add missing dependency for accumulators

### DIFF
--- a/BUILD.boost
+++ b/BUILD.boost
@@ -242,6 +242,7 @@ boost_library(
 boost_library(
     name = "accumulators",
     deps = [
+        ":circular_buffer",
         ":concept_check",
         ":config",
         ":fusion",


### PR DESCRIPTION
On darwin_arm64 with the following dependencies:

<details>
<summary>repositories.bzl</summary>

```starlark
load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")

def cc_deps():
    http_archive(
        name = "boost",
        build_file = "@com_github_nelhage_rules_boost//:BUILD.boost",
        patch_cmds = ["rm -f doc/pdf/BUILD"],
        patch_cmds_win = ["Remove-Item -Force doc/pdf/BUILD"],
        sha256 = "59c9b274bc451cf91a9ba1dd2c7fdcaf5d60b1b3aa83f2c9fa143417cc660722",
        strip_prefix = "boost_1_72_0",
        urls = "https://boostorg.jfrog.io/native/main/release/1.72.0/source/boost_1_72_0.tar.bz2",
    )

    http_archive(
        name = "com_github_facebook_zstd",
        build_file = "//third_party/cc/com_github_facebook_zstd:zstd.BUILD",
        sha256 = "7c42d56fac126929a6a85dbc73ff1db2411d04f104fae9bdea51305663a83fd0",
        strip_prefix = "zstd-1.5.2",
        url = "https://github.com/facebook/zstd/releases/download/v1.5.2/zstd-1.5.2.tar.gz",
    )

    http_archive(
        name = "com_github_nelhage_rules_boost",
        sha256 = "1557e4e1f2d009f14919dbf49b167f6616136d0cef1ca1cfada6ce0d4e3d6146",
        strip_prefix = "rules_boost-ef58870fe00ecb8047cd34324b8c21221387d5fc",
        url = "https://github.com/nelhage/rules_boost/archive/ef58870fe00ecb8047cd34324b8c21221387d5fc.tar.gz",
        patches = ["//third_party/cc:com_github_nelhage_rules_boost/01-accumulators.patch"],
        patch_args = ["-p1"],
    )

    http_archive(
        name = "net_zlib_zlib",
        build_file = "@com_github_nelhage_rules_boost//:BUILD.zlib",
        sha256 = "c3e5e9fdd5004dcb542feda5ee4f0ff0744628baf8ed2dd5d66f8ca1197cb1a1",
        strip_prefix = "zlib-1.2.11",
        urls = [
            "https://mirror.bazel.build/zlib.net/zlib-1.2.11.tar.gz",
            "https://zlib.net/zlib-1.2.11.tar.gz",
        ],
    )

    http_archive(
        name = "org_bzip_bzip2",
        build_file = "@com_github_nelhage_rules_boost//:BUILD.bzip2",
        sha256 = "ab5a03176ee106d3f0fa90e381da478ddae405918153cca248e682cd0c4a2269",
        strip_prefix = "bzip2-1.0.8",
        url = "https://sourceware.org/pub/bzip2/bzip2-1.0.8.tar.gz",
    )

    http_archive(
        name = "org_lzma_lzma",
        build_file = "@com_github_nelhage_rules_boost//:BUILD.lzma",
        sha256 = "71928b357d0a09a12a4b4c5fafca8c31c19b0e7d3b8ebb19622e96f26dbf28cb",
        strip_prefix = "xz-5.2.3",
        url = "https://phoenixnap.dl.sourceforge.net/project/lzmautils/xz-5.2.3.tar.gz",
    )
```

</details>

I get the following build error with a project using `@boost//:accumulators`:

```
In file included from external/boost/boost/accumulators/statistics/rolling_mean.hpp:19:
In file included from external/boost/boost/accumulators/statistics/rolling_sum.hpp:18:
external/boost/boost/accumulators/statistics/rolling_window.hpp:14:10: fatal error: 'boost/circular_buffer.hpp' file not found
#include <boost/circular_buffer.hpp>
         ^~~~~~~~~~~~~~~~~~~~~~~~~~~
1 error generated.
```

I looked at [boost 1.72](https://github.com/boostorg/boost/tree/boost-1.72.0) accumulators module and it indeed uses circular_buffer:

https://github.com/boostorg/accumulators/blob/b12a189fefd17ff3a6a68fc24b4135f0e0c498f6/include/boost/accumulators/statistics/rolling_window.hpp#L14


The following change resolve this issue.