### PR TITLE
Remove remaining config_settings, now that they're unnecessary and use macOS system libs

### DIFF
--- a/BUILD.lzma
+++ b/BUILD.lzma
@@ -40,37 +40,11 @@ copy_file(
 alias(
     name = "apple_config",
     actual = select({
-        ":aarch64": "config.lzma-ios-arm64.h",
-        ":arm": "config.lzma-ios-armv7.h",
-        ":x86_64": "config.lzma-osx-x86_64.h", # Configuration same as macOS
-        ":x86_32": "config.lzma-ios-i386.h",
+        "@platforms//cpu:aarch64": "config.lzma-ios-arm64.h",
+        "@platforms//cpu:arm": "config.lzma-ios-armv7.h",
+        "@platforms//cpu:x86_64": "config.lzma-osx-x86_64.h", # Configuration same as macOS
+        "@platforms//cpu:x86_32": "config.lzma-ios-i386.h",
     }),
-)
-
-# Longer term TODO: Blocked until at least after Bazel 5.1 has been released.
-# config_setting()s wrappers for constraint_values are necessary for alias rules in Bazel because of a bug in 5.0
-# Needs release of fix to https://github.com/bazelbuild/bazel/issues/13047, which will likely happen in 5.1
-# At that time, remove these config settings below and update their use in the alias above to the raw @platforms//os constraint_value()s
-# Note: There are other instances of this message to update or resolve in sync.
-
-config_setting(
-    name = "aarch64",
-    constraint_values = ["@platforms//cpu:aarch64"],
-)
-
-config_setting(
-    name = "arm",
-    constraint_values = ["@platforms//cpu:arm"],
-)
-
-config_setting(
-    name = "x86_64",
-    constraint_values = ["@platforms//cpu:x86_64"],
-)
-
-config_setting(
-    name = "x86_32",
-    constraint_values = ["@platforms//cpu:x86_32"],
 )
 
 cc_library(

--- a/BUILD.zlib
+++ b/BUILD.zlib
@@ -6,43 +6,9 @@ alias(
     name = "zlib",
     visibility = ["//visibility:public"],
     actual = selects.with_or({
-        (":android", ":ios", ":watchos", ":tvos"): ":zlib_system",
+        ("@platforms//os:android", "@platforms//os:ios", "@platforms//os:watchos", "@platforms//os:tvos"): ":zlib_system",
         "//conditions:default": ":zlib_source",
     })
-)
-
-# Longer term TODO: Blocked until at least after Bazel 5.1 has been released.
-# config_setting()s wrappers for constraint_values are necessary for alias rules in Bazel because of a bug in 5.0
-# Needs release of fix to https://github.com/bazelbuild/bazel/issues/13047, which will likely happen in 5.1
-# At that time, remove these config settings below and update their use in the alias above to the raw @platforms//os constraint_value()s
-# Note: There are other instances of this message to update or resolve in sync.
-
-config_setting(
-    name = "android",
-    constraint_values = [
-        "@platforms//os:android",
-    ],
-)
-
-config_setting(
-    name = "ios",
-    constraint_values = [
-        "@platforms//os:ios",
-    ],
-)
-
-config_setting(
-    name = "watchos",
-    constraint_values = [
-        "@platforms//os:watchos",
-    ],
-)
-
-config_setting(
-    name = "tvos",
-    constraint_values = [
-        "@platforms//os:tvos",
-    ],
 )
 
 cc_library(

--- a/BUILD.zlib
+++ b/BUILD.zlib
@@ -6,7 +6,7 @@ alias(
     name = "zlib",
     visibility = ["//visibility:public"],
     actual = selects.with_or({
-        ("@platforms//os:android", "@platforms//os:ios", "@platforms//os:watchos", "@platforms//os:tvos"): ":zlib_system",
+        ("@platforms//os:android", "@platforms//os:osx", "@platforms//os:ios", "@platforms//os:watchos", "@platforms//os:tvos"): ":zlib_system",
         "//conditions:default": ":zlib_source",
     })
 )


### PR DESCRIPTION
Hey, @nelhage.

This PR follows up on #247 and #245, cleaning out a workaround that is no longer needed with the release of Bazel 5.1.
It also switches things to use system libz on macOS, consistent with all the other Apple platforms. I know the system version has been significantly faster in the past, too.

The two are joined into one PR to avoid conflicts and because you've been open to that in the past.

Thanks for all you do!
Chris