### PR TITLE
link atomic_sse statically on windows_x86_64

### DIFF
--- a/BUILD.boost
+++ b/BUILD.boost
@@ -324,6 +324,10 @@ cc_library(
         "-msse4.1",
         "-Iexternal/boost/libs/atomic/src",
     ],
+    linkstatic = select({
+        ":windows_x86_64": True,
+        "//conditions:default": False,
+    }),
     visibility = ["//visibility:private"],
     deps = BOOST_ATOMIC_DEPS,
 )


### PR DESCRIPTION
not sure why this is needed, but fixes #236
tested using visual studio build tools 2019 version 14.29.30133.