### PR TITLE
Fix boost::container_hash build with libc++ 15.0.0 which removes std::unary_function

### DIFF
--- a/BUILD.boost
+++ b/BUILD.boost
@@ -628,6 +628,7 @@ boost_library(
 
 boost_library(
     name = "container_hash",
+    defines = ["BOOST_NO_CXX98_FUNCTION_BASE"],
     deps = [
         ":assert",
         ":config",


### PR DESCRIPTION
Fixes #264 . This might break things if you have an ancient compiler or version of the STL, but this has been deprecated since C++11 so I don't think it's a problem in practice.