### PR TITLE
Upgrade boringssl to work with clang 15

### DIFF
--- a/boost/boost.bzl
+++ b/boost/boost.bzl
@@ -221,7 +221,7 @@ def boost_deps():
     maybe(
         http_archive,
         name = "openssl",
-        sha256 = "6f640262999cd1fb33cf705922e453e835d2d20f3f06fe0d77f6426c19257308",
-        strip_prefix = "boringssl-fc44652a42b396e1645d5e72aba053349992136a",
-        url = "https://github.com/google/boringssl/archive/fc44652a42b396e1645d5e72aba053349992136a.tar.gz",
+        sha256 = "be8231e5f3b127d83eb156354dfa28c110e3c616c11ae119067c8184ef7a257f",
+        strip_prefix = "boringssl-3a3d0b5c7fddeea312b5ce032d9b84a2be399b32",
+        url = "https://github.com/google/boringssl/archive/3a3d0b5c7fddeea312b5ce032d9b84a2be399b32.tar.gz",
     )


### PR DESCRIPTION
Another fix for Clang 15, this time for boringssl. Without this change I get the following compile error:
```
external/openssl/src/crypto/x509/t_x509.c:500:18: error: variable 'l' set but not used [-Werror,-Wunused-but-set-variable]
    int ret = 0, l, i;
                 ^
```
The commit I'm updating to here is the latest commit in the master-with-bazel branch.