### PR TITLE
fix iOS lzma config file path

### DIFF
--- a/BUILD.lzma
+++ b/BUILD.lzma
@@ -40,10 +40,10 @@ copy_file(
 alias(
     name = "apple_config",
     actual = select({
-        "@platforms//cpu:aarch64": "config.lzma-ios-arm64.h",
-        "@platforms//cpu:arm": "config.lzma-ios-armv7.h",
-        "@platforms//cpu:x86_64": "config.lzma-osx-x86_64.h", # Configuration same as macOS
-        "@platforms//cpu:x86_32": "config.lzma-ios-i386.h",
+        "@platforms//cpu:aarch64": "@com_github_nelhage_rules_boost//:config.lzma-ios-arm64.h",
+        "@platforms//cpu:arm": "@com_github_nelhage_rules_boost//:config.lzma-ios-armv7.h",
+        "@platforms//cpu:x86_64": "@com_github_nelhage_rules_boost//:config.lzma-osx-x86_64.h", # Configuration same as macOS
+        "@platforms//cpu:x86_32": "@com_github_nelhage_rules_boost//:config.lzma-ios-i386.h",
     }),
 )
 

--- a/BUILD.lzma
+++ b/BUILD.lzma
@@ -40,8 +40,8 @@ copy_file(
 alias(
     name = "apple_config",
     actual = select({
-        "@platforms//cpu:aarch64": "@com_github_nelhage_rules_boost//:config.lzma-ios-arm64.h",
-        "@platforms//cpu:arm": "@com_github_nelhage_rules_boost//:config.lzma-ios-armv7.h",
+        "@platforms//cpu:arm64": "@com_github_nelhage_rules_boost//:config.lzma-ios-arm64.h",
+        "@platforms//cpu:armv7": "@com_github_nelhage_rules_boost//:config.lzma-ios-armv7.h",
         "@platforms//cpu:x86_64": "@com_github_nelhage_rules_boost//:config.lzma-osx-x86_64.h", # Configuration same as macOS
         "@platforms//cpu:x86_32": "@com_github_nelhage_rules_boost//:config.lzma-ios-i386.h",
     }),


### PR DESCRIPTION
When using this repo to build boost for iOS arm64/armv7 targets, there was an error saying:

```
Copying files failed: missing input file 'external/org_lzma_lzma/config.lzma-ios-arm64.h', owner: '@org_lzma_lzma//:config.lzma-ios-arm64.h
```

And taking a look at the `BUILD.lzma`, I found that paths are not pointing correctly so I've fixed them.
Also, the cpu constraint values has been updated to use latest ones.

btw, 32bit is deprecated for iOS devices so I guess at some point we can clean the `apple_config` a bit.