### PR TITLE
Add backup URL for boost 1.80.0 download

### DIFF
--- a/boost/boost.bzl
+++ b/boost/boost.bzl
@@ -214,6 +214,7 @@ def boost_deps():
         sha256 = "4b2136f98bdd1f5857f1c3dea9ac2018effe65286cf251534b6ae20cc45e1847",
         strip_prefix = "boost_1_80_0",
         urls = [
+            "https://mirror.bazel.build/boostorg.jfrog.io/artifactory/main/release/1.80.0/source/boost_1_80_0.tar.gz",
             "https://boostorg.jfrog.io/artifactory/main/release/1.80.0/source/boost_1_80_0.tar.gz",
         ],
     )


### PR DESCRIPTION
Had issues recently with the Artifactory download. Therefore, I added a fallback URL for boost download.