### PR TITLE
Update XZ Utils library

### DIFF
--- a/boost/boost.bzl
+++ b/boost/boost.bzl
@@ -171,8 +171,6 @@ def boost_deps():
         ],
     )
 
-    SOURCEFORGE_MIRRORS = ["phoenixnap", "newcontinuum", "cfhcable", "superb-sea2", "cytranet", "iweb", "gigenet", "ayera", "astuteinternet", "pilotfiber", "svwh"]
-
     maybe(
         http_archive,
         name = "org_bzip_bzip2",
@@ -182,14 +180,16 @@ def boost_deps():
         url = "https://sourceware.org/pub/bzip2/bzip2-1.0.8.tar.gz",
     )
 
+    SOURCEFORGE_MIRRORS = ["cfhcable", "superb-sea2", "cytranet", "iweb", "gigenet", "ayera", "astuteinternet", "pilotfiber", "svwh"]
+
     maybe(
         http_archive,
         name = "org_lzma_lzma",
         build_file = "@com_github_nelhage_rules_boost//:BUILD.lzma",
-        sha256 = "71928b357d0a09a12a4b4c5fafca8c31c19b0e7d3b8ebb19622e96f26dbf28cb",
-        strip_prefix = "xz-5.2.3",
+        sha256 = "06327c2ddc81e126a6d9a78b0be5014b976a2c0832f492dcfc4755d7facf6d33",
+        strip_prefix = "xz-5.2.7",
         urls = [
-            "https://%s.dl.sourceforge.net/project/lzmautils/xz-5.2.3.tar.gz" % m
+            "https://%s.dl.sourceforge.net/project/lzmautils/xz-5.2.7.tar.gz" % m
             for m in SOURCEFORGE_MIRRORS
         ],
     )


### PR DESCRIPTION
Update XZ Utils library from version 5.2.3 to 5.2.7

- Removed SOURCEFORGE_MIRRORS "phoenixnap" and "newcontinuum" because I get the following warning messages on my local dev environment:

```
WARNING: Download from https://phoenixnap.dl.sourceforge.net/project/lzmautils/xz-5.2.7.tar.gz failed: class java.net.NoRouteToHostException No route to host (Host unreachable)
WARNING: Download from https://newcontinuum.dl.sourceforge.net/project/lzmautils/xz-5.2.7.tar.gz failed: class javax.net.ssl.SSLHandshakeException PKIX path validation failed: java.security.cert.CertPathValidatorException: validity check failed
```

Also the CI reports the same WARNINGS:

```
(15:20:59) WARNING: Download from https://phoenixnap.dl.sourceforge.net/project/lzmautils/xz-5.2.3.tar.gz failed: class java.io.IOException connect timed out
--
  | (15:20:59) WARNING: Download from https://newcontinuum.dl.sourceforge.net/project/lzmautils/xz-5.2.3.tar.gz failed: class javax.net.ssl.SSLHandshakeException PKIX path validation failed: java.security.cert.CertPathValidatorException: validity check failed
```
