### PR TITLE
Add mirror download URL for bzip2

### DIFF
--- a/boost/boost.bzl
+++ b/boost/boost.bzl
@@ -179,7 +179,10 @@ def boost_deps():
         build_file = "@com_github_nelhage_rules_boost//:BUILD.bzip2",
         sha256 = "ab5a03176ee106d3f0fa90e381da478ddae405918153cca248e682cd0c4a2269",
         strip_prefix = "bzip2-1.0.8",
-        url = "https://sourceware.org/pub/bzip2/bzip2-1.0.8.tar.gz",
+        urls = [
+            "https://mirror.bazel.build/sourceware.org/pub/bzip2/bzip2-1.0.8.tar.gz",
+            "https://sourceware.org/pub/bzip2/bzip2-1.0.8.tar.gz",
+        ]
     )
 
     maybe(


### PR DESCRIPTION
This PR can be merged once the mirror URL for bzip2 is available: 
Depends-on: https://github.com/bazelbuild/bazel/issues/16529