### PR TITLE
Starting configuration for Renovate

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,5 +14,5 @@ jobs:
       - run: cd /tmp/ &&
           curl -LO https://github.com/bazelbuild/bazel/releases/download/5.2.0/bazel-5.2.0-installer-linux-x86_64.sh &&
           bash /tmp/bazel-5.2.0-installer-linux-x86_64.sh
-      - run: cd test && cp .bazelrc.ci .bazelrc
+      - run: cd test && cat .bazelrc.ci >> .bazelrc
       - run: cd test && bazel test --test_output=errors //...

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,5 +21,5 @@ script:
   - wget -q https://oplab9.parqtec.unicamp.br/pub/ppc64el/bazel/ubuntu_${dist_version}/bazel_bin_ppc64le_1.1.0
   - sudo mv bazel_bin_ppc64le_1.1.0 /usr/local/bin/bazel
   - sudo chmod +x /usr/local/bin/bazel
-  - cd $TRAVIS_BUILD_DIR/test && cp .bazelrc.ci .bazelrc
+  - cd $TRAVIS_BUILD_DIR/test && cat .bazelrc.ci >> .bazelrc
   - cd $TRAVIS_BUILD_DIR/test && bazel test --host_javabase=@local_jdk//:jdk --test_output=errors //...

--- a/boost/boost.bzl
+++ b/boost/boost.bzl
@@ -152,23 +152,18 @@ def boost_deps():
     maybe(
         http_archive,
         name = "bazel_skylib",
-        sha256 = "74d544d96f4a5bb630d465ca8bbcfe231e3594e5aae57e1edbf17a6eb3ca2506",
-        urls = [
-            "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/releases/download/1.3.0/bazel-skylib-1.3.0.tar.gz",
-            "https://github.com/bazelbuild/bazel-skylib/releases/download/1.3.0/bazel-skylib-1.3.0.tar.gz",
-        ],
+        url = "https://github.com/bazelbuild/bazel-skylib/archive/1.3.0.tar.gz",
+        sha256 = "3b620033ca48fcd6f5ef2ac85e0f6ec5639605fa2f627968490e52fc91a9932f",
+        strip_prefix = "bazel-skylib-1.3.0",
     )
 
     maybe(
         http_archive,
         name = "net_zlib_zlib",
         build_file = "@com_github_nelhage_rules_boost//:BUILD.zlib",
-        sha256 = "b3a24de97a8fdbc835b9833169501030b8977031bcb54b3b3ac13740f846ab30",
+        url = "https://github.com/madler/zlib/archive/v1.2.13.tar.gz",
+        sha256 = "1525952a0a567581792613a9723333d7f8cc20b87a81f920fb8bc7e3f2251428",
         strip_prefix = "zlib-1.2.13",
-        urls = [
-            "https://mirror.bazel.build/zlib.net/zlib-1.2.13.tar.gz",
-            "https://zlib.net/zlib-1.2.13.tar.gz",
-        ],
     )
 
     maybe(
@@ -201,11 +196,9 @@ def boost_deps():
         http_archive,
         name = "com_github_facebook_zstd",
         build_file = "@com_github_nelhage_rules_boost//:BUILD.zstd",
-        sha256 = "e28b2f2ed5710ea0d3a1ecac3f6a947a016b972b9dd30242369010e5f53d7002",
+        url = "https://github.com/facebook/zstd/archive/v1.5.1/zstd-1.5.1.tar.gz",
+        sha256 = "dc05773342b28f11658604381afd22cb0a13e8ba17ff2bd7516df377060c18dd",
         strip_prefix = "zstd-1.5.1",
-        urls = [
-            "https://github.com/facebook/zstd/releases/download/v1.5.1/zstd-1.5.1.tar.gz",
-        ],
     )
 
     maybe(
@@ -222,10 +215,11 @@ def boost_deps():
         ],
     )
 
+    # We're pointing at hedronvision's mirror of google/boringssl:master-with-bazel to get Renovate auto-update. Otherwise, Renovate will keep moving us back to master, which doesn't support Bazel. See https://github.com/renovatebot/renovate/issues/18492
     maybe(
         http_archive,
         name = "openssl",
-        sha256 = "6f640262999cd1fb33cf705922e453e835d2d20f3f06fe0d77f6426c19257308",
-        strip_prefix = "boringssl-fc44652a42b396e1645d5e72aba053349992136a",
-        url = "https://github.com/google/boringssl/archive/fc44652a42b396e1645d5e72aba053349992136a.tar.gz",
+        url = "https://github.com/hedronvision/boringssl/archive/71d6b947ba65b64da75425d319b16b43b26feced.tar.gz",
+        sha256 = "d88ce5f69555587294b76d79675ffb6f7ad752b14904acd359c267b94f2b89de",
+        strip_prefix = "boringssl-71d6b947ba65b64da75425d319b16b43b26feced",
     )

--- a/renovate.json5
+++ b/renovate.json5
@@ -1,0 +1,32 @@
+// This is the configuration file for Renovate, a GitHub App that can automate dependency updates.
+
+// If you're here, you're probably looking to:
+// (1) Make updates for a dependency fully automated. Whitelist it at <TAG0>
+// (2) Customize Renovate behavior further.
+  // For docs, see: https://docs.renovatebot.com/configuration-options/
+  // To debug, it can be helpful to looks at Renovate's runs/logs: https://app.renovatebot.com/dashboard#github/nelhage/rules_boost
+  // This file is .json5, so we can have helpful comments, like this one :) [Normal JSON, Renovate's default, has no comments.]
+// (3) Learn about what's going on here and what Renovate can do. Read on :)
+
+{
+  "packageRules": [{ // If you want a package to update on autopilot and have reasonably high confidence that updates won't break things, whitelist it here avoid having automated PRs to review.
+    "automerge": true, // Just automatically propose and merge in dependency upgrades to the latest.
+    "automergeType": "branch", // No PR unless tests fail; just do it.
+    "matchPackageNames" : [ // Add Bazel name= parameter here. <TAG0>.
+      "bazel_skylib",
+      "com_github_facebook_zstd",
+      "net_zlib_zlib",
+      "openssl",
+    ],
+  }],
+
+  // Defaults--and the tweaks we wish were defaults
+  "extends": ["config:base"], // Gives us the Renovate defaults (Renovate auto-added)
+  "separateMajorMinor": false, // Just always take the latest version.
+  // Remove limits added by config:base defaults.
+  "prConcurrentLimit": 0,
+  "prHourlyLimit": 0,
+  // Has Renovate maintain an issue with the status of dependencies--and a manual run button. Super handy but was originally not on by default.
+  "dependencyDashboard": true,
+  "dependencyDashboardHeader": "Collaborators: Check Renovate logs here: https://app.renovatebot.com/dashboard#github/nelhage/rules_boost", // Footer seems to prevent manual run checkbox, so I made this a header.
+}

--- a/test/.bazelrc
+++ b/test/.bazelrc
@@ -1,0 +1,7 @@
+# Use C++17.
+# C++14 is required for many tests and boringssl.
+# Some Boost libraries will soon require C++17.
+# And it's 2022 at the time of writing; C++20 support is widespread.
+build --cxxopt=-std=c++17
+build:windows --cxxopt=/std:c++17
+common --enable_platform_specific_config

--- a/test/BUILD.bazel
+++ b/test/BUILD.bazel
@@ -229,7 +229,6 @@ cc_test(
     name = "geometry_test",
     size = "small",
     srcs = ["geometry_test.cc"],
-    copts = ["-std=c++14"],
     deps = [
         "@boost//:geometry",
     ],
@@ -243,7 +242,6 @@ cc_test(
         "@boost//:histogram",
         "@boost//:format",
     ],
-    copts = ["-std=c++14"],
 )
 
 cc_test(
@@ -412,7 +410,6 @@ cc_test(
     name = "spirit_test",
     size = "small",
     srcs = ["spirit_test.cc"],
-    copts = ["-std=c++14"],
     deps = [
         "@boost//:spirit",
     ],
@@ -545,7 +542,6 @@ cc_test(
     name = "hana_test",
     size = "small",
     srcs = ["hana_test.cc"],
-    copts = ["-std=c++14"],
     deps = [
         "@boost//:hana",
     ],
@@ -555,7 +551,6 @@ cc_test(
     name = "variant2_test",
     size = "small",
     srcs = ["variant2_test.cc"],
-    copts = ["-std=c++14"],
     deps = [
         "@boost//:variant2",
     ],
@@ -575,7 +570,6 @@ cc_test(
     deps = [
         "@boost//:stl_interfaces",
     ],
-    copts = ["-std=c++1y"],
 )
 
 cc_test(
@@ -605,10 +599,6 @@ cc_test(
 cc_test(
     name = "pfr_test",
     srcs = ["pfr_test.cc"],
-    copts = select({
-        "@platforms//os:windows": ["/std:c++17"],
-        "//conditions:default": ["-std=c++17"],
-    }),
     deps = [
         "@boost//:pfr",
     ],


### PR DESCRIPTION
This configures Renovate to automate updates of boringssl, zlib, zstd, and skylib, so long as the update passes CI. This also massages dependency URLs into the format Renovate understands and updates the C++ version for tests.