### PR TITLE
Add note about platform_mappings

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,12 @@ boost_deps()
 
 You can now use libraries in `deps` through the `@boost` repository, for example `@boost//:algorithm`.
 
+## If you're using the Apple or Android-specific rules...
+
+As with all platform-dependent C/C++ in Bazel, you'll need to set up `platform_mappings` until Bazel resolves its outstanding issues.
+
+It's not hard if you know what to to do, but can be tricky to figure out. If you'd like help with this, please let us know over at https://github.com/hedronvision/bazel-make-cc-https-easy/issues/4
+
 ## Suggestion: Updates
 
 Improvements come frequently to the underlying libraries, including security patches, so we'd recommend keeping up-to-date.

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ You can now use libraries in `deps` through the `@boost` repository, for example
 
 ## If you're using the Apple or Android-specific rules...
 
-As with all platform-dependent C/C++ in Bazel, you'll need to set up `platform_mappings` until Bazel resolves its outstanding issues.
+As with all platform-dependent C/C++ in Bazel, you'll need to set up [`platform_mappings`](https://bazel.build/concepts/platforms#platform-mappings) until Bazel resolves its outstanding issues.
 
 It's not hard if you know what to to do, but can be tricky to figure out. If you'd like help with this, please let us know over at https://github.com/hedronvision/bazel-make-cc-https-easy/issues/4
 


### PR DESCRIPTION
@nelhage, one more where I'd like your approval

This is the platform_mappings note I'd mentioned in #274. Copying context from there

> One other thing I'd like to add to the README/setup if you're cool with it, copied over from another repo of mine: If people are trying to use this from the the Apple or Android-specific rules, they'll need to set up platform_mappings, until Bazel resolves its outstanding issues. These make the OS select()s work properly with the transitions in the implementations of those rules. It's not hard if you know what to to do, but can be tricky to figure out, and AFAIK, there aren't any working examples in their docs except ones I've commented to help people on issues. I don't have a public repo with instructions just yet--though I do have a working setup. What I'd like to do as a stopgap is to point people who want help over to a tracking issue (in that other repo), and, if there's demand, I'll spin up another repo we can both point to with instructions. In any event, it's worth giving people a heads up because otherwise they're likely to stumble into all sorts of hard-to-debug issues and report them.