### PR TITLE
suppress deprecated declaration warnings on regex

### DIFF
--- a/BUILD.boost
+++ b/BUILD.boost
@@ -1693,6 +1693,7 @@ boost_library(
     hdrs = [
         "boost/cregex.hpp",
     ],
+    copts = _w_no_deprecated,
     deps = [
         ":assert",
         ":config",


### PR DESCRIPTION
Latest C standard library in XCode 14.1 (MacOS) recently deprecated sprintf.