### PR TITLE
Export poly_collection and fix some missing dependencies

### DIFF
--- a/BUILD.boost
+++ b/BUILD.boost
@@ -368,6 +368,7 @@ boost_library(
     name = "array",
     deps = [
         ":assert",
+        ":concept_check",
         ":config",
         ":core",
         ":functional",
@@ -661,6 +662,7 @@ boost_library(
     name = "core",
     srcs = [
         "boost/checked_delete.hpp",
+        "boost/core/noinit_adaptor.hpp",
     ],
     deps = [
         ":config",
@@ -993,6 +995,8 @@ boost_library(
 boost_library(
     name = "heap",
     deps = [
+        ":array",
+        ":intrusive",
         ":parameter",
     ],
 )
@@ -1482,6 +1486,11 @@ boost_library(
 
 boost_library(
     name = "operators",
+    deps = [
+        ":config",
+        ":detail",
+        ":core",
+    ],
 )
 
 boost_library(
@@ -2421,7 +2430,11 @@ boost_library(
         "boost/pending/detail/property.hpp",
         "boost/pending/disjoint_sets.hpp",
         "boost/pending/indirect_cmp.hpp",
+        "boost/pending/is_heap.hpp",
+        "boost/pending/mutable_queue.hpp",
+        "boost/pending/mutable_heap.hpp",
         "boost/pending/property.hpp",
+        "boost/pending/property_serialize.hpp",
         "boost/pending/queue.hpp",
         "boost/pending/relaxed_heap.hpp",
     ],
@@ -2444,6 +2457,9 @@ boost_library(
 
 boost_library(
     name = "lambda",
+    deps = [
+        ":is_placeholder",
+    ]
 )
 
 boost_library(
@@ -2512,5 +2528,38 @@ boost_library(
         ":mp11",
         ":throw_exception",
         ":variant2",
+    ],
+)
+
+boost_library(
+    name = "poly_collection",
+    deps = [
+        ":assert",
+        ":config",
+        ":core",
+        ":iterator",
+        ":mp11",
+        ":type_erasure",
+        ":type_traits",
+    ],
+)
+
+boost_library(
+    name = "type_erasure",
+    deps = [
+        ":thread",
+        ":assert",
+        ":config",
+        ":fusion",
+        ":iterator",
+        ":mp11",
+        ":mpl",
+        ":preprocessor",
+        ":shared_ptr",
+        ":throw_exception",
+        ":typeof",
+        ":type_traits",
+        ":utility",
+        ":vmd",
     ],
 )

--- a/test/BUILD.bazel
+++ b/test/BUILD.bazel
@@ -337,6 +337,15 @@ cc_test(
 )
 
 cc_test(
+    name = "poly_collection_test",
+    size = "small",
+    srcs = ["poly_collection_test.cc"],
+    deps = [
+        "@boost//:poly_collection",
+    ],
+)
+
+cc_test(
     name = "process_test",
     size = "small",
     srcs = ["process_test.cc"],

--- a/test/poly_collection_test.cc
+++ b/test/poly_collection_test.cc
@@ -1,0 +1,15 @@
+#include <boost/poly_collection/base_collection.hpp>
+
+struct A {
+    virtual ~A() = default;
+};
+struct B : A {};
+struct C : A {};
+
+int main()
+{
+  boost::base_collection<A> collection;
+  collection.insert(B());
+  collection.insert(C());
+  return !(collection.size() == 2);
+}


### PR DESCRIPTION
Hi!

This is upstreaming some patches we've been maintaining for a while:
* Some missing headers/dependencies
* Adding poly_collection and type_erasure as its dependency.

First time in this repo, so please LMK if there's some PR convention I should follow here :)
