### PR TITLE
Fix old & add new sourceforge mirrors

### DIFF
--- a/boost/boost.bzl
+++ b/boost/boost.bzl
@@ -184,10 +184,10 @@ def boost_deps():
         http_archive,
         name = "org_lzma_lzma",
         build_file = "@com_github_nelhage_rules_boost//:BUILD.lzma",
-        sha256 = "e4b0f81582efa155ccf27bb88275254a429d44968e488fc94b806f2a61cd3e22",
-        strip_prefix = "xz-5.4.1",
+        sha256 = "7471ef5991f690268a8f2be019acec2e0564b7b233ca40035f339fe9a07f830b",
+        strip_prefix = "xz-5.4.0",
         urls = [
-            "https://%s.dl.sourceforge.net/project/lzmautils/xz-5.4.1.tar.gz" % m
+            "https://%s.dl.sourceforge.net/project/lzmautils/xz-5.4.0.tar.gz" % m
             for m in SOURCEFORGE_MIRRORS
         ],
     )

--- a/boost/boost.bzl
+++ b/boost/boost.bzl
@@ -175,10 +175,10 @@ def boost_deps():
         urls = [
             "https://mirror.bazel.build/sourceware.org/pub/bzip2/bzip2-1.0.8.tar.gz",
             "https://sourceware.org/pub/bzip2/bzip2-1.0.8.tar.gz",
-        ]
+        ],
     )
 
-    SOURCEFORGE_MIRRORS = ["cfhcable", "superb-sea2", "cytranet", "iweb", "gigenet", "ayera", "astuteinternet", "pilotfiber", "svwh"]
+    SOURCEFORGE_MIRRORS = ["altushost-swe", "cfhcable", "cytranet", "deac-ams", "deac-fra", "deac-riga", "excellmedia", "freefr", "gigenet", "ixpeering", "jaist", "kumisystems", "liquidtelecom", "nav", "nchc", "netcologne", "netix", "newcontinuum", "onboardcloud", "pilotfiber", "razaoinfo", "sinalbr", "sonik", "udomain", "ufpr", "versaweb", "yer"]
 
     maybe(
         http_archive,

--- a/boost/boost.bzl
+++ b/boost/boost.bzl
@@ -184,10 +184,10 @@ def boost_deps():
         http_archive,
         name = "org_lzma_lzma",
         build_file = "@com_github_nelhage_rules_boost//:BUILD.lzma",
-        sha256 = "7471ef5991f690268a8f2be019acec2e0564b7b233ca40035f339fe9a07f830b",
-        strip_prefix = "xz-5.4.0",
+        sha256 = "06327c2ddc81e126a6d9a78b0be5014b976a2c0832f492dcfc4755d7facf6d33",
+        strip_prefix = "xz-5.2.7",
         urls = [
-            "https://%s.dl.sourceforge.net/project/lzmautils/xz-5.4.0.tar.gz" % m
+            "https://%s.dl.sourceforge.net/project/lzmautils/xz-5.2.7.tar.gz" % m
             for m in SOURCEFORGE_MIRRORS
         ],
     )


### PR DESCRIPTION
### What's the focus of this PR?
Some users is having connectivity issues when downloading `lzmautils` because there were invalid (probably deprecated) sourceforge mirrors

Remove old sourceforge mirrors and add new ones according to https://sourceforge.net/p/forge/documentation/Mirrors/

