### PR TITLE
Remove unused sourceforge mirrors

### DIFF
--- a/boost/boost.bzl
+++ b/boost/boost.bzl
@@ -178,8 +178,6 @@ def boost_deps():
         ]
     )
 
-    SOURCEFORGE_MIRRORS = ["cfhcable", "superb-sea2", "cytranet", "iweb", "gigenet", "ayera", "astuteinternet", "pilotfiber", "svwh"]
-
     maybe(
         http_archive,
         name = "org_lzma_lzma",


### PR DESCRIPTION
We're no longer using sourceforge for liblzma, now that they've moved to GitHub, where we can get Renovate to help update.
See also https://github.com/nelhage/rules_boost/pull/360