### PR TITLE
Enable --keep_going by default, so all errors are reported.

### DIFF
--- a/test/.bazelrc
+++ b/test/.bazelrc
@@ -1,3 +1,7 @@
+# So all errors are reported, saving round trips on code review & CI
+# Optimizes for programmer time at the cost of some CPU
+build --keep_going
+
 # Use C++17.
 # C++14 is required for many tests and boringssl.
 # Some Boost libraries will soon require C++17.


### PR DESCRIPTION
@nelhage, okay with this? Goal is saving round trips on code review & CI, optimizing for programmer time at the cost of some CPU. The motivating example is @Vertexwahn's update of boost, which would have had a bunch fewer round trips if the layering check had reported all errors from the start.

Cheers,
Chris