### PR TITLE
uuid failing on windows

### DIFF
--- a/test/uuid_test.cc
+++ b/test/uuid_test.cc
@@ -3,7 +3,7 @@
 
 int main()
 {
-    boost::uuids::nil_generator gen;
+    boost::uuids::random_generator gen;
     boost::uuids::uuid u = gen();
     return u.is_nil() ? 0 : 1;
 }   


### PR DESCRIPTION
This repo fails to properly link `bcrypt.lib` from the windows sdk when running on Windows.

This produces the following error:

```bash
$ cd test && bazel test --test_output=errors //:uuid_test
...
uuid_test.obj : error LNK2019: unresolved external symbol BCryptCloseAlgorithmProvider referenced in function "private: void __cdecl boost::uuids::detail::random_provider_base::destroy(void)" (?destroy@random_provider_base@detail@uuids@boost@@AEAAXXZ)
uuid_test.obj : error LNK2019: unresolved external symbol BCryptGenRandom referenced in function "public: void __cdecl boost::uuids::detail::random_provider_base::get_random_bytes(void *,unsigned __int64)" (?get_random_bytes@random_provider_base@detail@uuids@boost@@QEAAXPEAX_K@Z)
uuid_test.obj : error LNK2019: unresolved external symbol BCryptOpenAlgorithmProvider referenced in function "public: __cdecl boost::uuids::detail::random_provider_base::random_provider_base(void)" (??0random_provider_base@detail@uuids@boost@@QEAA@XZ)
bazel-out\x64_windows-fastbuild\bin\uuid_test.exe : fatal error LNK1120: 3 unresolved externals
Target //:uuid_test failed to build
```

EDIT

[Stack overflow discussion](https://stackoverflow.com/questions/76158624/bazel-link-bcrypt-lib).

EDIT 2

Adding the following fixes the link error: `#pragma comment(lib, "bcrypt.lib")`.