### PR TITLE
Rename net_zlib_zlib->zlib

### DIFF
--- a/boost.BUILD
+++ b/boost.BUILD
@@ -1133,7 +1133,7 @@ boost_library(
         ":type_traits",
         ":utility",
         "@com_github_facebook_zstd//:zstd",
-        "@net_zlib_zlib//:zlib",
+        "@zlib",
         "@org_bzip_bzip2//:bz2lib",
         "@org_lzma_lzma//:lzma",
     ],

--- a/boost/boost.bzl
+++ b/boost/boost.bzl
@@ -117,7 +117,7 @@ def boost_deps():
 
     maybe(
         http_archive,
-        name = "net_zlib_zlib",
+        name = "zlib",
         build_file = "@com_github_nelhage_rules_boost//:zlib.BUILD",
         url = "https://github.com/madler/zlib/releases/download/v1.2.13/zlib-1.2.13.tar.gz",
         sha256 = "b3a24de97a8fdbc835b9833169501030b8977031bcb54b3b3ac13740f846ab30",

--- a/renovate.json5
+++ b/renovate.json5
@@ -15,7 +15,7 @@
       "bazel_skylib",
       "boost",
       "com_github_facebook_zstd",
-      "net_zlib_zlib",
+      "zlib",
       "openssl",
       "org_lzma_lzma",
       "ubuntu", // circleci, not Bazel.


### PR DESCRIPTION
This seems to be the standard name in Bazel land. fixes #416