### PR TITLE
boost.BUILD: fix windows platform bug

### DIFF
--- a/boost.BUILD
+++ b/boost.BUILD
@@ -1962,6 +1962,7 @@ boost_library(
         ":predef",
         ":utility",
         ":variant2",
+        ":winapi",
     ],
 )
 


### PR DESCRIPTION
System has winapi dependency, otherwise windows platform cross builds fail with:

external/boost/boost/system/detail/system_category_message_win32.hpp:14:10: fatal error: 'boost/winapi/error_handling.hpp' file not found #include <boost/winapi/error_handling.hpp>