### PR TITLE
Make renovate handle boost- version prefix

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -20,6 +20,10 @@
       "org_lzma_lzma",
       "ubuntu", // circleci, not Bazel.
     ],
+  }, {
+      "description": "Strip boost- prefix from boost release version names so Renovate parses them correctly.",
+      "matchPackageNames": ["boost"],
+      "extractVersion": "^boost-(?<version>.*)$"
   }],
 
   // Defaults--and the tweaks we wish were defaults


### PR DESCRIPTION
This should fix the lack of proposed auto-updates to boost. (Triggered by https://github.com/nelhage/rules_boost/pull/481)