### PR TITLE
Improve Renovate version handling

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -22,9 +22,9 @@
       "ubuntu", // circleci, not Bazel.
     ],
   }, {
-      "description": "Strip boost- prefix from boost release version names so Renovate parses them correctly.",
+      "description": "Handle boost- prefix from boost release version names.",
       "matchPackageNames": ["boost"],
-      "extractVersion": "^boost-(?<version>.*)$"
+      "versioning": "regex:^boost-(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)(\\.(?<prerelease>.+))?$",
   }],
 
   // Defaults--and the tweaks we wish were defaults


### PR DESCRIPTION
Goal is to fix issue where boost- prefix is stripped from URL on update. (See mistake in #529)

The unrelated build issues https://github.com/nelhage/rules_boost/pull/528#issuecomment-1865583689 will currently block merging-- @nelhage, if you have the ability to bypass checks and merge this in the meantime, that'd be awesome for being able to try it out in parallel.

Thanks--and sorry I didn't get this one right the first time around. May take another iteration; some of these Renovate configurations are a little complicated, but at least it saves polling.

-Chris