### PR TITLE
Remove *.ipp glob in Boost.Locale

### DIFF
--- a/boost.BUILD
+++ b/boost.BUILD
@@ -1167,7 +1167,6 @@ BOOST_LOCALE_COMMON_SOURCES = glob(
     [
         "libs/locale/src/boost/locale/encoding/*.cpp",
         "libs/locale/src/boost/locale/encoding/*.hpp",
-        "libs/locale/src/boost/locale/encoding/*.ipp",
         "libs/locale/src/boost/locale/shared/*.cpp",
         "libs/locale/src/boost/locale/shared/*.hpp",
         "libs/locale/src/boost/locale/std/*.cpp",


### PR DESCRIPTION
The files have been renamed from `*.ipp` to `*.hpp`. Keeping the glob leads to Bazel errors when using `--incompatible_disallow_empty_glob` (will become default in the future).