### PR TITLE
Add numeric_ublas to accumulators deps

### DIFF
--- a/boost.BUILD
+++ b/boost.BUILD
@@ -246,6 +246,7 @@ boost_library(
         ":config",
         ":fusion",
         ":mpl",
+        ":numeric_ublas",
         ":parameter",
         ":serialization",
         ":type_traits",


### PR DESCRIPTION
Fix the following error:

```
external/boost/libs/accumulators/include/boost/accumulators/statistics/covariance.hpp:21:10: fatal error: boost/numeric/ublas/io.hpp: No such file or directory
   21 | #include <boost/numeric/ublas/io.hpp>
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
```