### PR TITLE
Correct module name and repo_name

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,4 +1,4 @@
-module(name = "com_github_nelhage_rules_boost")
+module(name = "rules_boost", repo_name = "com_github_nelhage_rules_boost")
 
 bazel_dep(name = "bazel_skylib", version = "1.6.1")
 bazel_dep(name = "boringssl", version = "0.0.0-20240530-2db0eb3")

--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@ Copy this into your Bazel `MODULE.bazel` file to add this repo as an external de
 # Famous C++ library that has given rise to many new additions to the C++ Standard Library
 # Makes @boost available for use: For example, add `@boost//:algorithm` to your deps.
 # For more, see https://github.com/nelhage/rules_boost and https://www.boost.org
-bazel_dep(name = "com_github_nelhage_rules_boost")
+bazel_dep(name = "rules_boost", name = "com_github_nelhage_rules_boost")
 archive_override(
-    module_name = "com_github_nelhage_rules_boost",
+    module_name = "rules_boost",
     urls = "https://github.com/nelhage/rules_boost/archive/refs/heads/master.tar.gz",
     strip_prefix = "rules_boost-master",
     # It is recommended to edit the above URL and the below sha256 to point to a specific version of this repository.

--- a/test/MODULE.bazel
+++ b/test/MODULE.bazel
@@ -1,6 +1,6 @@
-bazel_dep(name = "com_github_nelhage_rules_boost")
+bazel_dep(name = "rules_boost", repo_name = "com_github_nelhage_rules_boost")
 local_path_override(
-    module_name = "com_github_nelhage_rules_boost",
+    module_name = "rules_boost",
     path = "..",
 )
 


### PR DESCRIPTION
The module name doesn't need to be aligned with the WORKSPACE name. When you follow [the documentation](https://bazel.build/external/migration) and see module [names in the BCR](https://github.com/bazelbuild/bazel-central-registry/tree/main/modules).
The name is the name of the project and the repo_name is the WORKSPACE  name.
This provide this normalisation