### PR TITLE
Add missing intrusive library dependency

### DIFF
--- a/boost.BUILD
+++ b/boost.BUILD
@@ -1107,6 +1107,7 @@ boost_library(
     deps = [
         ":assert",
         ":cstdint",
+        ":move",
         ":noncopyable",
         ":static_assert",
     ],


### PR DESCRIPTION
Intrusive depends on "move" library.