### PR TITLE
Add fusion dependency to iterator

### DIFF
--- a/boost.BUILD
+++ b/boost.BUILD
@@ -1096,6 +1096,7 @@ boost_library(
     name = "iterator",
     deps = [
         ":detail",
+        ":fusion",
         ":static_assert",
         ":type_traits",
         ":utility",


### PR DESCRIPTION
Iterator depends on fusion:

```
external/rules_boost~~non_module_dependencies~boost/libs/iterator/include/boost/iterator/zip_iterator.hpp:20:10: error: 'boost/fusion/adapted/boost_tuple.hpp' file not found [clang-diagnostic-error]
   20 | #include <boost/fusion/adapted/boost_tuple.hpp> // for backward compatibility
```