### PR TITLE
Adds limits as a dep to numeric_interval

### DIFF
--- a/boost.BUILD
+++ b/boost.BUILD
@@ -2268,6 +2268,9 @@ boost_library(
 boost_library(
     name = "numeric_interval",
     boost_name = "numeric/interval",
+    deps = [
+        ":limits"
+    ],
 )
 
 _BOOST_TEST_DEPS = [


### PR DESCRIPTION
When using `numeric_interval` as a dependency, it fails to build as `numeric/interval.hpp` includes `limits.h` but the dependency is not set up to consume ti

Error message:
```
external/rules_boost++non_module_dependencies+boost/libs/numeric/interval/include/boost/numeric/interval.hpp:14:10: fatal error: boost/limits.hpp: No such file or directory
   14 | #include <boost/limits.hpp>
      |          ^~~~~~~~~~~~~~~~~~
compilation terminated.
```