### PR TITLE
Bump boringssl

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,7 +1,7 @@
 module(name = "rules_boost", repo_name = "com_github_nelhage_rules_boost")
 
 bazel_dep(name = "bazel_skylib", version = "1.7.1")
-bazel_dep(name = "boringssl", version = "0.0.0-20240530-2db0eb3")
+bazel_dep(name = "boringssl", version = "0.20241209.0")
 bazel_dep(name = "bzip2", version = "1.0.8")
 bazel_dep(name = "platforms", version = "0.0.10")
 bazel_dep(name = "xz", version = "5.4.5.bcr.5")


### PR DESCRIPTION
The old version was incompatible with g++14, as far as I can tell. Looks like g++14 got stricter about only allowing `_Generic` with the appropriate version flags, or something.