### PR TITLE
container_hash: use consistent define

### DIFF
--- a/boost.BUILD
+++ b/boost.BUILD
@@ -648,7 +648,7 @@ boost_library(
 
 boost_library(
     name = "container_hash",
-    defines = ["BOOST_NO_CXX98_FUNCTION_BASE"],
+    defines = ["BOOST_NO_CXX98_FUNCTION_BASE="],
     deps = [
         ":assert",
         ":config",


### PR DESCRIPTION
Containder has has `defines = ["BOOST_NO_CXX98_FUNCTION_BASE"] added as a workaround for compilation on clang 15 with libc++. I believe this is no longer necessary as around the same time autotection of this property was added to boost, see [1].

rules_boost defines this value to 1 (because it passes -DBOOST_NO_CXX98_FUNCTION_BASE with no explicit value, which results in defining it as 1), but the autotection in boost libcpp.hpp defines it to be empty. This results in a redefinition conflict with some compiler or clangd options.

I'm too chicken to remove this define entirely but let us just define it empty to be consistent with boost.

---

[1] https://github.com/boostorg/config/commit/f0af4a9184457939b89110795ae2d293582c5f66